### PR TITLE
fix: Fallback `git describe` string for tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,10 @@ from setuptools import find_packages, setup
 
 def tag_version():
     """Generate version number from Git Tag, e.g. v2.0.0, v2.0.0-1."""
-    recent_tag = subprocess.check_output(shlex.split('git describe --long'))
+    try:
+        recent_tag = subprocess.check_output(shlex.split('git describe --long'))
+    except subprocess.CalledProcessError:
+        recent_tag = b'v0.0-0-00000000'
     tag, count, _ = recent_tag.decode().split('-')
     version = 'a'.join([tag, count]) if int(count) else tag
     return version


### PR DESCRIPTION
When `tox` runs, `git describe` fails to generate the version number.
This provides a safe default in the case when the command fails to
generate a version number.