### PR TITLE
Added support for modifying associatePublicIpAddress

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -119,6 +119,18 @@ Determines if the instances should be public (external) or non-public (internal)
        - ``"internal"``
        -  ``"external"``
 
+``enable_public_ips``
+******************
+
+Determines if instances in an cluster should have public IPs associated. By default, this is set to null which means it uses default behavior configured for your subnets in your cloud provider.
+
+    | *Type*: boolean
+    | *Default*: `null`
+    | *Options*
+
+       - ``true``
+       - ``false``
+    `
 ``scaling_policy``
 ******************
 

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -161,6 +161,7 @@ def construct_pipeline_block(env='',
     data['asg'].update({
         'hc_type': data['asg'].get('hc_type').upper(),
         'provider_healthcheck': json.dumps(health_checks.providers),
+        'enable_public_ips': json.dumps(settings['asg']['enable_public_ips']),
         "has_provider_healthcheck": health_checks.has_healthcheck,
     })
 

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -14,6 +14,7 @@
         "max_inst": 3,
         "min_inst": 1,
         "subnet_purpose": "internal",
+        "enable_public_ips": null,
         "provider_healthcheck": {
             "amazon": false
         },

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -43,7 +43,7 @@
           "loadBalancers": {{ data.app.elb }},
           "instanceType": "{{ data.app.instance_type }}",
           "useSourceCapacity": false,
-          "associatePublicIpAddress": null,
+          "associatePublicIpAddress": {{ data.asg.enable_public_ips }},
           "provider": "aws",
           "cloudProvider": "aws",
           "account": "{{ data.app.environment }}"


### PR DESCRIPTION
This fixes #59. This enables modification of default subnet associateIpAddress behavior. By default, it leaves it as `null` or in other words `default`