### PR TITLE
Split tox into code / lint checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py34,py35,py36,lint
 skip_missing_interpreters = True
 
 [pytest]
@@ -7,7 +7,9 @@ pep8maxlinelength = 120
 
 [testenv]
 deps = -rrequirements-dev.txt
-        prospector[with_everything]
-commands = prospector -0 -I __init__.py --strictness veryhigh --max-line-length 120
-           py.test -s -v --cov-report term-missing --cov-report html --cov foremast
+commands = py.test -s -v --cov-report term-missing --cov-report html --cov foremast
 recreate = True
+
+[testenv:lint]
+deps = prospector[with_everything]
+commands = prospector -0 -I __init__.py --strictness veryhigh --max-line-length 120


### PR DESCRIPTION
Its probably best to split code and linting tests. A linting check shouldn't necessarily fail a unit test.