### PR TITLE
Feat/pipeline types

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -48,6 +48,16 @@ Comma delimiated list of environments/applications that will be managed with For
     | *Example*: ``dev,stage,prod``
     | *Required*: Yes
 
+``types``
+~~~~~~~~~
+
+List of foremast managed Pipeline types to allow.
+
+    | *Type*: str
+    | *Example*: ``ec2,lambda,manual``
+    | *Default*: ``ec2,lambda``
+    | *Required*: No
+
 ``regions``
 ***********
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -112,6 +112,7 @@ GIT_URL = validate_key_values(config, 'base', 'git_url')
 DOMAIN = validate_key_values(config, 'base', 'domain', default='example.com')
 ENVS = set(validate_key_values(config, 'base', 'envs', default='').split(','))
 REGIONS = set(validate_key_values(config, 'base', 'regions', default='').split(','))
+ALLOWED_TYPES = set(validate_key_values(config, 'base', 'types', default='ec2,lambda').split(','))
 TEMPLATES_PATH = validate_key_values(config, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
 DEFAULT_EC2_SECURITYGROUPS = set(validate_key_values(config, 'base', 'default_ec2_securitygroups',

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -97,6 +97,9 @@ class ForemastRunner(object):
 
         pipeline_type = self.configs['pipeline']['type']
 
+        if pipeline_type not in consts.ALLOWED_TYPES:
+            raise NotImplementedError('Pipeline type "{0}" not permitted.'.format(pipeline_type))
+
         if not onetime:
             if pipeline_type == 'ec2':
                 spinnakerpipeline = pipeline.SpinnakerPipeline(**kwargs)

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -95,10 +95,12 @@ class ForemastRunner(object):
             'base': None,
         }
 
+        pipeline_type = self.configs['pipeline']['type']
+
         if not onetime:
-            if self.configs['pipeline']['type'] == 'ec2':
+            if pipeline_type == 'ec2':
                 spinnakerpipeline = pipeline.SpinnakerPipeline(**kwargs)
-            elif self.configs['pipeline']['type'] == 'lambda':
+            elif pipeline_type == 'lambda':
                 spinnakerpipeline = pipeline.SpinnakerPipelineLambda(**kwargs)
             else:
                 raise NotImplementedError("Pipeline type is not implemented.")

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -15,7 +15,8 @@
 #   limitations under the License.
 
 from configparser import ConfigParser
-from foremast.consts import extract_formats
+
+from foremast.consts import ALLOWED_TYPES, extract_formats
 
 
 def test_consts_extract_formats():
@@ -31,3 +32,9 @@ def test_consts_extract_formats():
 
     results = extract_formats(config)
     assert 'example.com' == results['domain']
+
+
+def test_consts_pipeline_types():
+    """Default types should be set."""
+    assert 'ec2' in ALLOWED_TYPES
+    assert 'lambda' in ALLOWED_TYPES


### PR DESCRIPTION
Provide a way to restrict what deployment types are allowed. This allows for administrators to block certain types, like the upcoming `manual` type, if support is not desired.