### PR TITLE
feat: adding elasticache template

### DIFF
--- a/src/foremast/templates/infrastructure/iam/elasticache.json.j2
+++ b/src/foremast/templates/infrastructure/iam/elasticache.json.j2
@@ -1,0 +1,15 @@
+        {
+            "Sid": "ElasticacheFullAccess",
+            "Effect": "Allow",
+            "Action": [
+                "elasticache:*"
+            ],
+            "Resource": [
+            {%- for cluster_name in items %}
+                "arn:aws:elasticace:{{ region }}:{{ account_number }}:cluster/{{ cluster_name }}"
+                {%- if not loop.last -%}
+                ,
+                {%- endif -%}
+            {% endfor %} 
+            ]
+        }


### PR DESCRIPTION
Fixes #75 

I'm very well versed in elasticache but this follows what the docs list. The s3 bucket is used when restoring from a snapshot so I'm not sure if that would come in to play for how foremast uses these templates or if it is still needed if not restoring. 


