### PR TITLE
Updated renumerate function to remove hardcoded stage names

### DIFF
--- a/src/foremast/pipeline/renumerate_stages.py
+++ b/src/foremast/pipeline/renumerate_stages.py
@@ -36,14 +36,14 @@ def renumerate_stages(pipeline):
 
     main_index = 0
     for stage in stages:
-        if stage['refId'] == 'a':
+        if stage['refId'].lower() == 'master':
             if main_index == 0:
                 stage['requisiteStageRefIds'] = []
             else:
                 stage['requisiteStageRefIds'] = [str(main_index)]
             main_index += 1
             stage['refId'] = str(main_index)
-        elif stage['refId'] == 'b':
+        elif stage['refId'].lower() == 'branch':
             stage['refId'] = str(main_index*100)
             stage['requisiteStageRefIds'] = [str(main_index)]
 

--- a/src/foremast/pipeline/renumerate_stages.py
+++ b/src/foremast/pipeline/renumerate_stages.py
@@ -22,9 +22,13 @@ LOG = logging.getLogger(__name__)
 
 def renumerate_stages(pipeline):
     """Renumber Pipeline Stage reference IDs to account for dependencies.
-       stage order is defined in the templates.
-       refId == 'a' - Any mainline required stage
-       refId == 'b' - Any secondary stage that should be ran in parallel
+
+    stage order is defined in the templates. The ``refId`` field dictates
+    if a stage should be mainline or parallel to other stages.
+
+        * ``master`` - A mainline required stage. Other stages depend on it
+        * ``branch`` - A stage that should be ran in parallel to master stages.
+        * ``merge`` - A stage thatis parallel but other stages still depend on it.
 
     Args:
         pipeline (dict): Completed Pipeline ready for renumeration.
@@ -36,16 +40,20 @@ def renumerate_stages(pipeline):
 
     main_index = 0
     for stage in stages:
-        if stage['refId'].lower() == 'master':
+        current_refId = stage['refId'].lower()
+        if current_refId == 'master':
             if main_index == 0:
                 stage['requisiteStageRefIds'] = []
             else:
                 stage['requisiteStageRefIds'] = [str(main_index)]
             main_index += 1
             stage['refId'] = str(main_index)
-        elif stage['refId'].lower() == 'branch':
+        elif current_refId == 'branch':
             stage['refId'] = str(main_index*100)
             stage['requisiteStageRefIds'] = [str(main_index)]
+        elif current_refId == 'merge':
+            # ToDo: Added logic to handle merge stages.
+            continue
 
         LOG.debug('step=%(name)s\trefId=%(refId)s\t'
                   'requisiteStageRefIds=%(requisiteStageRefIds)s', stage)

--- a/src/foremast/pipeline/renumerate_stages.py
+++ b/src/foremast/pipeline/renumerate_stages.py
@@ -53,7 +53,7 @@ def renumerate_stages(pipeline):
             stage['requisiteStageRefIds'] = [str(main_index)]
         elif current_refId == 'merge':
             # ToDo: Added logic to handle merge stages.
-            continue
+            pass
 
         LOG.debug('step=%(name)s\trefId=%(refId)s\t'
                   'requisiteStageRefIds=%(requisiteStageRefIds)s', stage)

--- a/src/foremast/templates/pipeline/stage-bake.json.j2
+++ b/src/foremast/templates/pipeline/stage-bake.json.j2
@@ -1,7 +1,7 @@
 
     {
       "requisiteStageRefIds": [],
-      "refId": "a",
+      "refId": "master",
       "type": "bake",
       "name": "Bake [{{ data.app.region }}]",
       "cloudProviderType": "aws",

--- a/src/foremast/templates/pipeline/stage-bake.json.j2
+++ b/src/foremast/templates/pipeline/stage-bake.json.j2
@@ -1,7 +1,7 @@
 
     {
       "requisiteStageRefIds": [],
-      "refId": "1",
+      "refId": "a",
       "type": "bake",
       "name": "Bake [{{ data.app.region }}]",
       "cloudProviderType": "aws",

--- a/src/foremast/templates/pipeline/stage-deploy-lambda.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy-lambda.json.j2
@@ -1,8 +1,6 @@
 {
-    "requisiteStageRefIds": [
-      "5"
-    ],
-    "refId": "6",
+    "requisiteStageRefIds": [""],
+    "refId": "a",
     "type": "jenkins",
     "comments": "Upload Lambda .zip file to [{{ data.app.environment }}]",
     "name": "Deploy Lambda [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-deploy-lambda.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy-lambda.json.j2
@@ -1,6 +1,6 @@
 {
     "requisiteStageRefIds": [""],
-    "refId": "a",
+    "refId": "master",
     "type": "jenkins",
     "comments": "Upload Lambda .zip file to [{{ data.app.environment }}]",
     "name": "Deploy Lambda [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -1,7 +1,7 @@
 
     {
-      "requisiteStageRefIds": ["5"],
-      "refId": "6",
+      "requisiteStageRefIds": [""],
+      "refId": "a",
       "type": "deploy",
       "name": "Deploy {{ data.app.environment }}",
       "clusters": [

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -1,7 +1,7 @@
 
     {
       "requisiteStageRefIds": [""],
-      "refId": "a",
+      "refId": "master",
       "type": "deploy",
       "name": "Deploy {{ data.app.environment }}",
       "clusters": [

--- a/src/foremast/templates/pipeline/stage-infrastructure-setup-lambda.json.j2
+++ b/src/foremast/templates/pipeline/stage-infrastructure-setup-lambda.json.j2
@@ -1,8 +1,6 @@
   {
-      "requisiteStageRefIds": [
-        "6"
-      ],
-      "refId": "7",
+      "requisiteStageRefIds": [""],
+      "refId": "a",
       "type": "jenkins",
       "comments": "This stage will run the infrastructure setup scripts to setup ELBs, security groups, and s3 buckets in <b>{{ data.app.environment }}</b>. This will look at the applications runway/ configuration files to determine setup",
       "name": "Infrastructure Setup Lambda [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-infrastructure-setup-lambda.json.j2
+++ b/src/foremast/templates/pipeline/stage-infrastructure-setup-lambda.json.j2
@@ -1,6 +1,6 @@
   {
       "requisiteStageRefIds": [""],
-      "refId": "a",
+      "refId": "master",
       "type": "jenkins",
       "comments": "This stage will run the infrastructure setup scripts to setup ELBs, security groups, and s3 buckets in <b>{{ data.app.environment }}</b>. This will look at the applications runway/ configuration files to determine setup",
       "name": "Infrastructure Setup Lambda [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-infrastructure-setup.json.j2
+++ b/src/foremast/templates/pipeline/stage-infrastructure-setup.json.j2
@@ -1,8 +1,6 @@
   {
-      "requisiteStageRefIds": [
-        "6"
-      ],
-      "refId": "7",
+      "requisiteStageRefIds": [""],
+      "refId": "a",
       "type": "jenkins",
       "comments": "This stage will run the infrastructure setup scripts to setup ELBs, security groups, and s3 buckets in <b>{{ data.app.environment }}</b>. This will look at the applications runway/ configuration files to determine setup",
       "name": "Infrastructure Setup [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-infrastructure-setup.json.j2
+++ b/src/foremast/templates/pipeline/stage-infrastructure-setup.json.j2
@@ -1,6 +1,6 @@
   {
       "requisiteStageRefIds": [""],
-      "refId": "a",
+      "refId": "master",
       "type": "jenkins",
       "comments": "This stage will run the infrastructure setup scripts to setup ELBs, security groups, and s3 buckets in <b>{{ data.app.environment }}</b>. This will look at the applications runway/ configuration files to determine setup",
       "name": "Infrastructure Setup [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
+++ b/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
@@ -1,7 +1,7 @@
 
     {
-      "requisiteStageRefIds":["7"],
-      "refId": "8",
+      "requisiteStageRefIds":[""],
+      "refId": "a",
       "type": "manualJudgment",
       "name": "Checkpoint {{ data.app.environment }}",
       "notifications": [],

--- a/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
+++ b/src/foremast/templates/pipeline/stage-judgement-nonprod.json.j2
@@ -1,7 +1,7 @@
 
     {
       "requisiteStageRefIds":[""],
-      "refId": "a",
+      "refId": "master",
       "type": "manualJudgment",
       "name": "Checkpoint {{ data.app.environment }}",
       "notifications": [],

--- a/src/foremast/templates/pipeline/stage-scaling-policy.json.j2
+++ b/src/foremast/templates/pipeline/stage-scaling-policy.json.j2
@@ -1,8 +1,6 @@
   {
-      "requisiteStageRefIds": [
-        "6"
-      ],
-      "refId": "800",
+      "requisiteStageRefIds": [""],
+      "refId": "b",
       "type": "jenkins",
       "comments": "This stage will apply a scaling policy if provided in <b>{{ data.app.environment }}</b>.",
       "name": "Attach Scaling Policy [{{ data.app.environment }}]",

--- a/src/foremast/templates/pipeline/stage-scaling-policy.json.j2
+++ b/src/foremast/templates/pipeline/stage-scaling-policy.json.j2
@@ -1,6 +1,6 @@
   {
       "requisiteStageRefIds": [""],
-      "refId": "b",
+      "refId": "branch",
       "type": "jenkins",
       "comments": "This stage will apply a scaling policy if provided in <b>{{ data.app.environment }}</b>.",
       "name": "Attach Scaling Policy [{{ data.app.environment }}]",


### PR DESCRIPTION
fixes #58 

I changed the logic to look for `"a"` or `"b"`  in the stage templates. Stages marked with `"a"` are mainline required pipeline stages. stages marked with `"b"` are secondary parallel stages. The order is already handled by https://github.com/gogoair/foremast/blob/master/src/foremast/templates/pipeline/pipeline_stages.json.j2 template.

This change would break existing templates, but makes the enumerate code a lot cleaner and supportable.


I tested this against our current pipeline and it works consistently. 