### PR TITLE
feat: Manual Pipeline support

### DIFF
--- a/_docs/configuration_files/pipeline_json/index.rst
+++ b/_docs/configuration_files/pipeline_json/index.rst
@@ -19,6 +19,7 @@ Example Configuration
 Configuration Details
 ----------------------
 
+.. _pipeline_type:
 
 ``type``
 ~~~~~~~~
@@ -30,6 +31,7 @@ Specifies what type of pipeline to use for the application.
 
         - ``"lambda"`` - Sets up the AWS Lambda pipeline and infrastructure
         - ``"ec2"`` - Sets up the AWS EC2 pipeline and infrastructure
+        - ``"manual"`` - Create Pipelines from raw JSON, use with :ref:`pipeline_files`.
 
 ``owner_email``
 ~~~~~~~~~~~~~~~
@@ -74,6 +76,7 @@ List of accounts that the application will be deployed to. Order matters as it d
     | *Type*: List of strings
     | *Default*: ``["stage", "prod"]``
 
+.. include:: manual.rest
 .. include:: image.rest
 .. include:: lambda.rest
 .. include:: services.rest

--- a/_docs/configuration_files/pipeline_json/manual.rest
+++ b/_docs/configuration_files/pipeline_json/manual.rest
@@ -1,0 +1,9 @@
+.. _pipeline_files:
+
+``pipeline_files``
+~~~~~~~~~~~~~~~~~~
+
+List of JSON files to use for ``manual`` :ref:`pipeline_type`.
+
+    | *Type*: list
+    | *Default*: ``[]``

--- a/src/foremast/pipeline/__init__.py
+++ b/src/foremast/pipeline/__init__.py
@@ -16,5 +16,6 @@
 
 """Package for the creation of spinnaker pipelines"""
 from .create_pipeline import SpinnakerPipeline
-from .create_pipeline_onetime import SpinnakerPipelineOnetime
 from .create_pipeline_lambda import SpinnakerPipelineLambda
+from .create_pipeline_manual import SpinnakerPipelineManual
+from .create_pipeline_onetime import SpinnakerPipelineOnetime

--- a/src/foremast/pipeline/clean_pipelines.py
+++ b/src/foremast/pipeline/clean_pipelines.py
@@ -26,6 +26,20 @@ from ..utils import check_managed_pipeline, get_all_pipelines
 LOG = logging.getLogger(__name__)
 
 
+def delete_pipeline(app='', pipeline_name=''):
+    """Delete _pipeline_name_ from _app_."""
+    url = murl.Url(API_URL)
+
+    LOG.warning('Deleting Pipeline: %s', pipeline_name)
+
+    url.path = 'pipelines/{app}/{pipeline}'.format(app=app, pipeline=pipeline_name)
+    response = requests.delete(url.url, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
+
+    LOG.debug('Deleted "%s" Pipeline response:\n%s', pipeline_name, response.text)
+
+    return response.text
+
+
 def clean_pipelines(app='', settings=None):
     """Delete Pipelines for regions not defined in application.json files.
 
@@ -44,7 +58,6 @@ def clean_pipelines(app='', settings=None):
         SpinnakerPipelineCreationFailed: Missing application.json file from
         `create-configs`.
     """
-    url = murl.Url(API_URL)
     pipelines = get_all_pipelines(app=app)
     envs = settings['pipeline']['env']
 
@@ -70,11 +83,6 @@ def clean_pipelines(app='', settings=None):
         LOG.debug('Check "%s" in defined Regions.', region)
 
         if region not in regions:
-            LOG.warning('Deleting Pipeline: %s', pipeline_name)
-
-            url.path = 'pipelines/{app}/{pipeline}'.format(app=app, pipeline=pipeline_name)
-            response = requests.delete(url.url, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
-
-            LOG.debug('Deleted "%s" Pipeline response:\n%s', pipeline_name, response.text)
+            delete_pipeline(app=app, pipeline_name=pipeline_name)
 
     return True

--- a/src/foremast/pipeline/clean_pipelines.py
+++ b/src/foremast/pipeline/clean_pipelines.py
@@ -13,14 +13,13 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 """Clean removed Pipelines."""
 import logging
 
 import murl
 import requests
 
-from ..consts import API_URL, GATE_CLIENT_CERT, GATE_CA_BUNDLE
+from ..consts import API_URL, GATE_CA_BUNDLE, GATE_CLIENT_CERT
 from ..exceptions import SpinnakerPipelineCreationFailed
 from ..utils import check_managed_pipeline, get_all_pipelines
 
@@ -56,8 +55,7 @@ def clean_pipelines(app='', settings=None):
         try:
             regions.update(settings[env]['regions'])
         except KeyError:
-            raise SpinnakerPipelineCreationFailed(
-                'Missing "runway/application-master-{0}.json".'.format(env))
+            raise SpinnakerPipelineCreationFailed('Missing "runway/application-master-{0}.json".'.format(env))
     LOG.debug('Regions defined: %s', regions)
 
     for pipeline in pipelines:
@@ -74,13 +72,9 @@ def clean_pipelines(app='', settings=None):
         if region not in regions:
             LOG.warning('Deleting Pipeline: %s', pipeline_name)
 
-            url.path = 'pipelines/{app}/{pipeline}'.format(
-                app=app, pipeline=pipeline_name)
-            response = requests.delete(url.url,
-                                       verify=GATE_CA_BUNDLE,
-                                       cert=GATE_CLIENT_CERT)
+            url.path = 'pipelines/{app}/{pipeline}'.format(app=app, pipeline=pipeline_name)
+            response = requests.delete(url.url, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
 
-            LOG.debug('Deleted "%s" Pipeline response:\n%s', pipeline_name,
-                      response.text)
+            LOG.debug('Deleted "%s" Pipeline response:\n%s', pipeline_name, response.text)
 
     return True

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -54,7 +54,7 @@ class SpinnakerPipeline:
         self.header = {'content-type': 'application/json'}
         self.here = os.path.dirname(os.path.realpath(__file__))
 
-        self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
+        self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir or ''))
 
         self.base = base
         self.trigger_job = trigger_job

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -40,17 +40,21 @@ class SpinnakerPipeline:
         trigger_job (str): Jenkins trigger job.
         base (str): Base image name (i.e: fedora).
         prop_path (str): Path to the raw.properties.json.
+        runway_dir (str): Path to local runway directory.
     """
 
     def __init__(self,
                  app='',
                  trigger_job='',
                  prop_path='',
-                 base=''):
+                 base='',
+                 runway_dir=''):
         self.log = logging.getLogger(__name__)
 
         self.header = {'content-type': 'application/json'}
         self.here = os.path.dirname(os.path.realpath(__file__))
+
+        self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
 
         self.base = base
         self.trigger_job = trigger_job

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Create manual Pipeline for Spinnaker."""
-from ..utils.lookups import GitLookup
+from ..utils.lookups import FileLookup
 from .create_pipeline import SpinnakerPipeline
 
 
@@ -24,7 +24,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
     def create_pipeline(self):
         """Use JSON files to create Pipelines."""
         self.log.info('Uploading manual Pipelines: %s')
-        lookup = GitLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
+        lookup = FileLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
 
         for json_file in self.settings['pipeline']['pipeline_files']:
             json_text = lookup.get(filename=json_file)

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -1,0 +1,33 @@
+#   Foremast - Pipeline Tooling
+#
+#   Copyright 2016 Gogo, LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Create manual Pipeline for Spinnaker."""
+from ..utils.lookups import GitLookup
+from .create_pipeline import SpinnakerPipeline
+
+
+class SpinnakerPipelineManual(SpinnakerPipeline):
+    """Manual JSON configured Spinnaker Pipelines."""
+
+    def create_pipeline(self):
+        """Use JSON files to create Pipelines."""
+        self.log.info('Uploading manual Pipelines: %s')
+        lookup = GitLookup(git_short=self.generated.gitlab()['main'])
+
+        for json_file in self.settings['pipeline']['pipeline_files']:
+            json_text = lookup.get(filename=json_file)
+            self.post_pipeline(json_text)
+
+        return True

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 """Create manual Pipeline for Spinnaker."""
 from ..utils.lookups import FileLookup
+from .clean_pipelines import delete_pipeline
 from .create_pipeline import SpinnakerPipeline
 
 
@@ -27,6 +28,8 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         lookup = FileLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
 
         for json_file in self.settings['pipeline']['pipeline_files']:
+            delete_pipeline(app=self.app_name, pipeline_name=json_file)
+
             json_dict = lookup.json(filename=json_file)
             json_dict['name'] = json_file
             self.post_pipeline(json_dict)

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -27,7 +27,8 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         lookup = FileLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
 
         for json_file in self.settings['pipeline']['pipeline_files']:
-            json_text = lookup.get(filename=json_file)
-            self.post_pipeline(json_text)
+            json_dict = lookup.json(filename=json_file)
+            json_dict['name'] = json_file
+            self.post_pipeline(json_dict)
 
         return True

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -24,7 +24,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
     def create_pipeline(self):
         """Use JSON files to create Pipelines."""
         self.log.info('Uploading manual Pipelines: %s')
-        lookup = GitLookup(git_short=self.generated.gitlab()['main'])
+        lookup = GitLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
 
         for json_file in self.settings['pipeline']['pipeline_files']:
             json_text = lookup.get(filename=json_file)

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -105,6 +105,8 @@ class ForemastRunner(object):
                 spinnakerpipeline = pipeline.SpinnakerPipeline(**kwargs)
             elif pipeline_type == 'lambda':
                 spinnakerpipeline = pipeline.SpinnakerPipelineLambda(**kwargs)
+            elif pipeline_type == 'manual':
+                spinnakerpipeline = pipeline.SpinnakerPipelineManual(**kwargs)
             else:
                 raise NotImplementedError("Pipeline type is not implemented.")
         else:

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -93,6 +93,7 @@ class ForemastRunner(object):
             'trigger_job': self.trigger_job,
             'prop_path': self.json_path,
             'base': None,
+            'runway_dir': self.runway_dir,
         }
 
         pipeline_type = self.configs['pipeline']['type']

--- a/src/foremast/templates/configs/pipeline.json.j2
+++ b/src/foremast/templates/configs/pipeline.json.j2
@@ -19,5 +19,6 @@
         "runtime": "java8",
         "handler": "main",
         "vpc_enabled": false
-    }
+    },
+    "pipeline_files": []
 }


### PR DESCRIPTION
When `{"type": "manual"}`, use the listed files in `{"pipeline_files": []}` to create Pipelines.

See also: #74
Closes: #72