### PR TITLE
Support IAM TLS Certificate Templates -- Helps with TLS Certificate Rotation

### DIFF
--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from ..utils import get_env_credential, get_template
-from ..exceptions import ForemastError
+from ..exceptions import ForemastTemplateNotFound
 
 LOG = logging.getLogger(__name__)
 
@@ -168,7 +168,7 @@ def generate_custom_cert_name(env='', account='', certificate=None):
     # TODO: Investigate moving this to a remote API, then fallback to local file if unable to connect
     try:
         rendered_template = get_template(template_file='infrastructure/tlscert_naming.json.j2', **template_kwargs)
-    except ForemastError:
+    except ForemastTemplateNotFound:
         LOG.info('Unable to find TLS Cert Template; Falling back to default logic...')
         return cert_name
 

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -134,12 +134,15 @@ def format_cert_name(env='', account='', certificate=None):
 
     if certificate:
         if certificate.startswith('arn'):
+            LOG.info("Full ARN provided...skipping lookup.")
             cert_name = certificate
         else:
             generated_cert_name = generate_custom_cert_name(env, account, certificate)
             if generated_cert_name:
+                LOG.info("Found generated certificate %s from template", generated_cert_name)
                 cert_name = generated_cert_name
             else:
+                LOG.info("Using default certificate name logic")
                 cert_name = ('arn:aws:iam::{account}:server-certificate/{name}'.format(account=account,
                                                                                        name=certificate))
     LOG.debug('Certificate name: %s', cert_name)
@@ -167,9 +170,9 @@ def generate_custom_cert_name(env='', account='', certificate=None):
 
     # TODO: Investigate moving this to a remote API, then fallback to local file if unable to connect
     try:
-        rendered_template = get_template(template_file='infrastructure/tlscert_naming.json.j2', **template_kwargs)
+        rendered_template = get_template(template_file='infrastructure/iam/tlscert_naming.json.j2', **template_kwargs)
     except ForemastTemplateNotFound:
-        LOG.info('Unable to find TLS Cert Template; Falling back to default logic...')
+        LOG.info('Unable to find TLS Cert Template...falling back to default logic...')
         return cert_name
 
     try:

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -18,8 +18,8 @@
 import json
 import logging
 
-from ..utils import get_env_credential, get_template
 from ..exceptions import ForemastTemplateNotFound
+from ..utils import get_env_credential, get_template
 
 LOG = logging.getLogger(__name__)
 
@@ -175,6 +175,6 @@ def generate_custom_cert_name(env='', account='', certificate=None):
     try:
         cert_name = json.loads(rendered_template)[env][certificate]
     except KeyError:
-        LOG.error("Unable to find TLS certificate named {0} under {1} in TLS Cert Template".format(certificate, env))
+        LOG.error("Unable to find TLS certificate named %s under %s in TLS Cert Template", certificate, env)
 
     return cert_name

--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -21,6 +21,11 @@ class ForemastError(Exception):
     pass
 
 
+class ForemastTemplateNotFound(Exception):
+    """Foremast Template was not found."""
+    pass
+
+
 class SpinnakerError(ForemastError):
     """Spinnaker related error."""
     pass

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -21,7 +21,7 @@ import os
 import jinja2
 
 from ..consts import TEMPLATES_PATH
-from ..exceptions import ForemastError
+from ..exceptions import ForemastTemplateNotFound
 
 LOG = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def get_template_object(template_file=''):
         LOG.error("Unable to find template {0} in specified template path {1}".format(
             template_file, TEMPLATES_PATH
         ))
-        raise ForemastError
+        raise ForemastTemplateNotFound
 
     return template
 
@@ -72,7 +72,7 @@ def get_template(template_file='', **kwargs):
     """
     try:
         template = get_template_object(template_file)
-    except ForemastError:
+    except ForemastTemplateNotFound:
         raise
 
     LOG.info('Rendering template %s', template.filename)

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -33,9 +33,8 @@ def get_template_object(template_file=''):
         template_file (str): name of the template file
 
     Returns:
-        template (Template): Template jinja2 object
+        jinja2.Template: Template jinja2 object
     """
-
     here = os.path.dirname(os.path.realpath(__file__))
     local_templates = '{0}/../templates/'.format(here)
     jinja_lst = []
@@ -52,8 +51,9 @@ def get_template_object(template_file=''):
     try:
         template = jinjaenv.get_template(template_file)
     except jinja2.TemplateNotFound:
-        LOG.error("Unable to find template %s in specified template path %s", template_file, TEMPLATES_PATH)
-        raise ForemastTemplateNotFound
+        LOG.debug("Unable to find template %s in specified template path %s", template_file, TEMPLATES_PATH)
+        raise ForemastTemplateNotFound("Unable to find template %s in specified template path %s",
+                                       template_file, TEMPLATES_PATH)
 
     return template
 

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -52,9 +52,7 @@ def get_template_object(template_file=''):
     try:
         template = jinjaenv.get_template(template_file)
     except jinja2.TemplateNotFound:
-        LOG.error("Unable to find template {0} in specified template path {1}".format(
-            template_file, TEMPLATES_PATH
-        ))
+        LOG.error("Unable to find template %s in specified template path %s", template_file, TEMPLATES_PATH)
         raise ForemastTemplateNotFound
 
     return template

--- a/tests/test_valid_json_templates.py
+++ b/tests/test_valid_json_templates.py
@@ -18,14 +18,13 @@
 import pytest
 import json
 
-from jinja2 import Template
-from jinja2.exceptions import TemplateNotFound
+from foremast.exceptions import ForemastTemplateNotFound
 
 from foremast.utils import get_template
 
 
 def test_get_template():
-    with pytest.raises(TemplateNotFound):
+    with pytest.raises(ForemastTemplateNotFound):
         template = get_template(template_file='doesnotexist.json.j2')
 
 


### PR DESCRIPTION
Today, Amazon has issues with rotating TLS/SSL certificates in AWS. The workflow is as follows:

1. Create SSL Cert
2. Upload it to AWS with different name
3. Update all references to new certificate

Today, step 3 means every developer will need to update their foremast configs in their individual repos to the latest name. This is fine, but in emergency situations, this can cause a widespread impact. 

With this Pull Request, I want to support the classic way of naming (not to break current users of foremast), and also enable setting of custom certificate names based on a template. We plan on using `<cert_name>-<date_of_expiry>`, but this will enable folks to set whatever naming they want and also even abstract SSL key names to end users so they can specify friendly names as well.

This is related to the example config mentioned here: https://github.com/gogoair/foremast-template-examples/pull/1