### PR TITLE
Updated lambda policy after AWS addressed a bug in their documentation:

### DIFF
--- a/src/foremast/templates/infrastructure/iam/lambda.json.j2
+++ b/src/foremast/templates/infrastructure/iam/lambda.json.j2
@@ -3,6 +3,9 @@
             "Action": [
             {% if settings.lambda.vpc_enabled %}
                 "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DetachNetworkInterface",
             {% endif %}
                 "lambda:*",
                 "logs:CreateLogGroup",


### PR DESCRIPTION
Amazon has mentioned there was an issue in their documentation:

See the new docs here.
http://docs.aws.amazon.com/lambda/latest/dg/policy-templates.html#LambdaVPCAccessExecutionRole