### PR TITLE
Changed pipeline_id to be None if no existing pipeline exists.

### DIFF
--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -175,7 +175,7 @@ class SpinnakerPipeline:
             str: pipeline_id if existing, empty string of not.
         """
         pipelines = self.get_existing_pipelines()
-        pipeline_id = ''
+        pipeline_id = None
         for pipeline in pipelines:
             if (pipeline['application'] == self.app_name) and (region in pipeline['name']):
                 self.log.info('Existing pipeline found - %s', pipeline['name'])

--- a/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
@@ -1,6 +1,8 @@
 {
   "name": "{{ data.app.appname }} [{{ data.app.region }}]",
+  {% if data.id %}
   "id": "{{ data.id }}",
+  {% endif %}
   "application": "{{ data.app.appname }}",
   "triggers": [
     {% include "pipeline/trigger-jenkins.json.j2" %}


### PR DESCRIPTION
This fixes an issue where the empty string causes problems in S3.

It tested this against an S3 and Cassanada backend for Front50. Keeping the value None instead of an empty string works in both. 

