### PR TITLE
changed default_provider to discovery

### DIFF
--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -26,7 +26,7 @@ from ..utils import generate_encoded_user_data, get_template
 LOG = logging.getLogger(__name__)
 
 
-def check_provider_healthcheck(settings, default_provider='Amazon'):
+def check_provider_healthcheck(settings, default_provider='Discovery'):
     """Set Provider Health Check when specified.
 
     Returns:

--- a/tests/pipeline/test_provider_healthcheck.py
+++ b/tests/pipeline/test_provider_healthcheck.py
@@ -19,7 +19,7 @@ def test_setting_eureka_enabled():
     eureka_enabled_settings['app']['eureka_enabled'] = True
 
     health_checks = check_provider_healthcheck(settings=eureka_enabled_settings)
-    assert health_checks.providers == ['Amazon']
+    assert health_checks.providers == ['Discovery']
     assert health_checks.has_healthcheck is True
 
 
@@ -44,7 +44,7 @@ def test_additional_provider_with_eureka():
 
     health_checks = check_provider_healthcheck(settings=eureka_enabled_with_provider_settings)
     assert len(health_checks.providers) == 2
-    assert 'Amazon' in health_checks.providers
+    assert 'Discovery' in health_checks.providers
     assert 'cloud' not in health_checks.providers
     assert 'Cloud' in health_checks.providers
     assert health_checks.has_healthcheck is True


### PR DESCRIPTION
This was `Amazon` for Eureka deployments but this causes it not to check Eureka healthchecks, only Amazon. Changed default to `Discovery` and this solves the issues. ELB deployments work the same as before. 