### PR TITLE
fix: Handle missing env

### DIFF
--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -26,6 +26,10 @@ class ForemastTemplateNotFound(Exception):
     pass
 
 
+class ForemastConfigurationFileError(ForemastError):
+    """Foremast configuration file misconfigured."""
+
+
 class SpinnakerError(ForemastError):
     """Spinnaker related error."""
     pass

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -172,10 +172,19 @@ class SpinnakerSecurityGroup(object):
 
         Returns:
             boolean: True if created successfully
-        """
 
-        ingress = self.properties['security_group']['ingress']
+        Raises:
+            SpinnakerSecurityGroupError: Missing environment configuration or
+                misconfigured Security Group definition.
+        """
         ingress_rules = []
+
+        try:
+            ingress = self.properties['security_group']['ingress']
+        except KeyError:
+            msg = 'Possible missing configuration for "{0}".'.format(self.env)
+            self.log.error(msg)
+            raise SpinnakerSecurityGroupError(msg)
 
         for app in ingress:
             rules = ingress[app]

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -46,7 +46,8 @@ import logging
 import boto3
 from boto3.exceptions import botocore
 
-from ..exceptions import SpinnakerSecurityGroupCreationFailed, SpinnakerSecurityGroupError
+from ..exceptions import (ForemastConfigurationFileError, SpinnakerSecurityGroupCreationFailed,
+                          SpinnakerSecurityGroupError)
 from ..utils import check_task, get_properties, get_security_group_id, get_template, get_vpc_id, post_task, warn_user
 
 
@@ -174,7 +175,7 @@ class SpinnakerSecurityGroup(object):
             boolean: True if created successfully
 
         Raises:
-            SpinnakerSecurityGroupError: Missing environment configuration or
+            ForemastConfigurationFileError: Missing environment configuration or
                 misconfigured Security Group definition.
         """
         ingress_rules = []
@@ -184,7 +185,7 @@ class SpinnakerSecurityGroup(object):
         except KeyError:
             msg = 'Possible missing configuration for "{0}".'.format(self.env)
             self.log.error(msg)
-            raise SpinnakerSecurityGroupError(msg)
+            raise ForemastConfigurationFileError(msg)
 
         for app in ingress:
             rules = ingress[app]

--- a/tests/test_securitygroup.py
+++ b/tests/test_securitygroup.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
-from foremast.exceptions import SpinnakerSecurityGroupError
+from foremast.exceptions import ForemastConfigurationFileError
 from foremast.securitygroup import SpinnakerSecurityGroup
 
 SAMPLE_JSON = """{"security_group": {
@@ -64,7 +64,7 @@ def test_missing_configuration(get_properties):
 
     security_group = SpinnakerSecurityGroup()
 
-    with pytest.raises(SpinnakerSecurityGroupError):
+    with pytest.raises(ForemastConfigurationFileError):
         security_group.create_security_group()
 
 
@@ -75,5 +75,5 @@ def test_misconfiguration(get_properties):
 
     security_group = SpinnakerSecurityGroup()
 
-    with pytest.raises(SpinnakerSecurityGroupError):
+    with pytest.raises(ForemastConfigurationFileError):
         security_group.create_security_group()

--- a/tests/test_securitygroup.py
+++ b/tests/test_securitygroup.py
@@ -16,6 +16,10 @@
 """Ensure Security Groups get created properly"""
 import json
 from unittest.mock import patch
+
+import pytest
+
+from foremast.exceptions import SpinnakerSecurityGroupError
 from foremast.securitygroup import SpinnakerSecurityGroup
 
 SAMPLE_JSON = """{"security_group": {
@@ -51,3 +55,25 @@ def test_create_crossaccount_securitygroup(pipeline_config, post_task, get_vpc_i
 
     x = SpinnakerSecurityGroup(app='edgeforrest', env='dev', region='us-east-1')
     assert x.create_security_group() is True
+
+
+@patch('foremast.securitygroup.create_securitygroup.get_properties')
+def test_missing_configuration(get_properties):
+    """Make missing Security Group configurations more apparent."""
+    get_properties.return_value = {}
+
+    security_group = SpinnakerSecurityGroup()
+
+    with pytest.raises(SpinnakerSecurityGroupError):
+        security_group.create_security_group()
+
+
+@patch('foremast.securitygroup.create_securitygroup.get_properties')
+def test_misconfiguration(get_properties):
+    """Make bad Security Group definitions more apparent."""
+    get_properties.return_value = {'security_group': {}}
+
+    security_group = SpinnakerSecurityGroup()
+
+    with pytest.raises(SpinnakerSecurityGroupError):
+        security_group.create_security_group()


### PR DESCRIPTION
When `pipeline.json` is configured with the wrong environments or the Security Group definition is missing in the `application.json`, we should alert with a more informative error.
