### PR TITLE
Updated ElasticSearch Permissions

### DIFF
--- a/_docs/configuration_files/pipeline_json/services.rest
+++ b/_docs/configuration_files/pipeline_json/services.rest
@@ -29,6 +29,14 @@ Add DynamoDB access to tables listed.
    | *Type*: list
    | *Default*: ``[]``
 
+``elasticsearch``
+************
+
+Add ElasticSearch access to domains listed.
+
+   | *Type*: list
+   | *Default*: ``[]``
+
 ``lambda``
 **********
 

--- a/src/foremast/templates/infrastructure/iam/elasticsearch.json.j2
+++ b/src/foremast/templates/infrastructure/iam/elasticsearch.json.j2
@@ -1,9 +1,12 @@
         {
-            "Sid": "ElasticSearchCreateDelete",
-            "Action": [
-                "es:CreateElasticsearchDomain",
-                "es:DeleteElasticsearchDomain"
-            ],
+            "Sid": "ElasticSearchFullAccess",
+            "Action": ["es:*"],
             "Effect": "Allow",
-            "Resource": "*"
+            "Resource": [
+            {%- for esdomain in items %}
+                "arn:aws:es:{{ region }}:{{ account_number }}:domain/{{ esdomain }}/*"
+                {%- if not loop.last -%}
+                ,
+                {%- endif -%}
+            {% endfor %}
         }


### PR DESCRIPTION
It appears ElasticSearch has a bunch of hidden and undocumented IAM permissions. For example,  es:ESHttpGet is one used to do HTTP Get requests against a specified domain. This PR updates the policy to enable users to specify a list of ES Domains as well as give the recommended access as per https://forums.aws.amazon.com/message.jspa?messageID=678366

Docs updated as well as I noticed this was missing as well.