### PR TITLE
Fixed typo in firehose policy template

### DIFF
--- a/src/foremast/templates/infrastructure/iam/firehose.json.j2
+++ b/src/foremast/templates/infrastructure/iam/firehose.json.j2
@@ -6,7 +6,7 @@
             "Effect": "Allow",
             "Resource": [
             {%- for stream in items %}
-                "arn:aws:dynamodb:{{ region }}:{{ account_number }}:deliverystream/{{ stream }}"
+                "arn:aws:firehose:{{ region }}:{{ account_number }}:deliverystream/{{ stream }}"
                 {%- if not loop.last -%}
                 ,
                 {%- endif -%}


### PR DESCRIPTION
There was a typo in the policy for firehose (it was granting dynamo not firehose)