### PR TITLE
fix: Include api details in docs

### DIFF
--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
+    'sphinx_autodoc_annotation',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 pytest-cov
 pytest-pep8
 sphinx
+sphinx-autodoc-annotation
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 tox


### PR DESCRIPTION
Fix docs so they include api details within the 'Foremast Modules" section.