### PR TITLE
fix: Manual pipeline safe name

### DIFF
--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -14,9 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Create manual Pipeline for Spinnaker."""
-from ..utils import normalize_pipeline_name
+from ..utils import get_pipeline_id, normalize_pipeline_name
 from ..utils.lookups import FileLookup
-from .clean_pipelines import delete_pipeline
 from .create_pipeline import SpinnakerPipeline
 
 
@@ -36,7 +35,7 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
             json_dict.setdefault('application', self.app_name)
             json_dict.setdefault('name', normalize_pipeline_name(name=json_file))
 
-            delete_pipeline(app=json_dict['application'], pipeline_name=json_dict['name'])
+            json_dict.setdefault('id', get_pipeline_id(app=json_dict['application'], name=json_dict['name']))
 
             self.post_pipeline(json_dict)
 

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -31,12 +31,12 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
         lookup = FileLookup(git_short=self.generated.gitlab()['main'], runway_dir=self.runway_dir)
 
         for json_file in pipelines:
-            delete_pipeline(app=self.app_name, pipeline_name=json_file)
-
             json_dict = lookup.json(filename=json_file)
 
             json_dict.setdefault('application', self.app_name)
             json_dict.setdefault('name', normalize_pipeline_name(name=json_file))
+
+            delete_pipeline(app=json_dict['application'], pipeline_name=json_dict['name'])
 
             self.post_pipeline(json_dict)
 

--- a/src/foremast/pipeline/create_pipeline_manual.py
+++ b/src/foremast/pipeline/create_pipeline_manual.py
@@ -34,8 +34,10 @@ class SpinnakerPipelineManual(SpinnakerPipeline):
             delete_pipeline(app=self.app_name, pipeline_name=json_file)
 
             json_dict = lookup.json(filename=json_file)
-            json_dict['application'] = self.app_name
-            json_dict['name'] = normalize_pipeline_name(name=json_file)
+
+            json_dict.setdefault('application', self.app_name)
+            json_dict.setdefault('name', normalize_pipeline_name(name=json_file))
+
             self.post_pipeline(json_dict)
 
         return True

--- a/src/foremast/utils/pipelines.py
+++ b/src/foremast/utils/pipelines.py
@@ -85,10 +85,11 @@ def get_all_pipelines(app=''):
     return pipelines
 
 
-def get_pipeline_id(name=''):
+def get_pipeline_id(app='', name=''):
     """Get the ID for Pipeline _name_.
 
     Args:
+        app (str): Name of Spinnaker Application to search.
         name (str): Name of Pipeline to get ID for.
 
     Returns:
@@ -97,7 +98,7 @@ def get_pipeline_id(name=''):
     """
     return_id = None
 
-    pipelines = get_all_pipelines(name)
+    pipelines = get_all_pipelines(app=app)
 
     for pipeline in pipelines:
         LOG.debug('ID of %(name)s: %(id)s', pipeline)

--- a/src/foremast/utils/pipelines.py
+++ b/src/foremast/utils/pipelines.py
@@ -108,3 +108,11 @@ def get_pipeline_id(name=''):
             break
 
     return return_id
+
+
+def normalize_pipeline_name(name=''):
+    """Translate unsafe characters to underscores."""
+    normalized_name = name
+    for bad in '\\/?%#':
+        normalized_name = normalized_name.replace(bad, '_')
+    return normalized_name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,16 +81,18 @@ def test_utils_pipeline_get_all_pipelines(mock_murl, mock_requests_get):
 
 @mock.patch('foremast.utils.pipelines.get_all_pipelines')
 def test_utils_pipeline_get_pipeline_id(mock_get_pipelines):
-
+    """Verify Pipeline ID response."""
     data = [
         {'name': 'app', 'id': 100},
     ]
     mock_get_pipelines.return_value = data
 
-    result = get_pipeline_id(name='app')
+    result = get_pipeline_id(app='test', name='app')
+    mock_get_pipelines.assert_called_once_with(app='test')
     assert result is 100
 
-    result = get_pipeline_id(name='badapp')
+    result = get_pipeline_id(app='embarrassingly', name='badapp')
+    mock_get_pipelines.assert_called_with(app='embarrassingly')
     assert result == None
 
 

--- a/tests/utils/test_string_formatting.py
+++ b/tests/utils/test_string_formatting.py
@@ -1,0 +1,19 @@
+"""Tests for string formatting functions."""
+from foremast.utils.pipelines import normalize_pipeline_name
+
+SAFE_PIPELINE_NAMES = {
+    '#pudding/pop': '_pudding_pop',
+    'caesar?salad': 'caesar_salad',
+    'chutes&ladders.json': 'chutes&ladders.json',
+    'conga-line': 'conga-line',
+    'DAKOTA\\ACCESS': 'DAKOTA_ACCESS',
+    'jelly/baby': 'jelly_baby',
+    'pizza%2Fpie': 'pizza_2Fpie',
+    'water': 'water',
+}
+
+
+def test_safe_pipeline_names():
+    """Check Pipeline name safe formatting."""
+    for raw, safe in SAFE_PIPELINE_NAMES.items():
+        assert normalize_pipeline_name(name=raw) == safe


### PR DESCRIPTION
Need to remove bad characters from the generated Pipeline name in accordance with Spinnaker's name checker. This allows manual Pipelines to be created and deleted properly.