### PR TITLE
fix: Delete Pipeline

### DIFF
--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -92,6 +92,10 @@ class SpinnakerPipelineCreationFailed(SpinnakerError):
     pass
 
 
+class SpinnakerPipelineDeletionFailed(SpinnakerError):
+    """Could not delete Spinnaker Pipeline."""
+
+
 class SpinnakerSecurityGroupCreationFailed(SpinnakerError):
     """Could not create Security Group."""
     pass


### PR DESCRIPTION
Add handling for bad Pipeline deletion request. Gate returns the `method_not_allowed` status code when deleting really cannot be completed, most likely from an improper Pipeline name.