### PR TITLE
added cookie_ttl support and fixed bug with duplicate stickiness policy

### DIFF
--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -165,14 +165,18 @@ class SpinnakerELB:
             if listener.get("stickiness"):
                 sticky_type = listener['stickiness']['type'].lower()
                 externalport = int(listener['loadbalancer'].split(":")[-1])
-                policyname = "{0}-{1}cookie-{2}".format(self.app, sticky_type, externalport)
                 if sticky_type == 'app':
+                    cookiename = listener['stickiness']['cookie_name']
+                    policyname = "{0}-{1}cookie-{2}-{3}".format(self.app, sticky_type, externalport, cookiename)
                     elbclient.create_app_cookie_stickiness_policy(LoadBalancerName=self.app,
                                                                   PolicyName=policyname,
-                                                                  CookieName=listener['stickiness']['cookie_name'])
+                                                                  CookieName=cookiename)
                     stickiness_dict[externalport] = policyname
                 elif sticky_type == 'elb':
+                    cookie_ttl = listener['stickiness'].get('cookie_ttl', 0)
+                    policyname = "{0}-{1}cookie-{2}-{3}".format(self.app, sticky_type, externalport, cookie_ttl)
                     elbclient.create_lb_cookie_stickiness_policy(LoadBalancerName=self.app,
-                                                                 PolicyName=policyname)
+                                                                 PolicyName=policyname,
+                                                                 CookieExpirationPeriod=cookie_ttl)
                     stickiness_dict[externalport] = policyname
         return stickiness_dict

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -165,16 +165,17 @@ class SpinnakerELB:
             if listener.get("stickiness"):
                 sticky_type = listener['stickiness']['type'].lower()
                 externalport = int(listener['loadbalancer'].split(":")[-1])
+                policyname_tmp = "{0}-{1}-{2}-{3}"
                 if sticky_type == 'app':
                     cookiename = listener['stickiness']['cookie_name']
-                    policyname = "{0}-{1}cookie-{2}-{3}".format(self.app, sticky_type, externalport, cookiename)
+                    policyname = policyname_tmp.format(self.app, sticky_type, externalport, cookiename)
                     elbclient.create_app_cookie_stickiness_policy(LoadBalancerName=self.app,
                                                                   PolicyName=policyname,
                                                                   CookieName=cookiename)
                     stickiness_dict[externalport] = policyname
                 elif sticky_type == 'elb':
                     cookie_ttl = listener['stickiness'].get('cookie_ttl', 0)
-                    policyname = "{0}-{1}cookie-{2}-{3}".format(self.app, sticky_type, externalport, cookie_ttl)
+                    policyname = policyname_tmp.format(self.app, sticky_type, externalport, cookie_ttl)
                     elbclient.create_lb_cookie_stickiness_policy(LoadBalancerName=self.app,
                                                                  PolicyName=policyname,
                                                                  CookieExpirationPeriod=cookie_ttl)


### PR DESCRIPTION
As per requested, I added support for setting a LB cookie TTL for stickiness. This defaults to 0 which means no TTL.

I also expanded on the policy name to fix an issue with creating duplicate policies and not allowing a policy to change. 