### PR TITLE
Added support for backend server policies in foremast config

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -260,6 +260,24 @@ Defines ELB listeners. Expects a list of listeners.
 
         | *Default*: ``null``
 
+    ``listener_policies`` : A list of listener policies to associate to an ELB. Must be created in AWS first.
+
+        | *Default*: ``[]``
+
+        | *Type*: List of strings
+
+    ``backend_policies`` : A list of backend server policies to associate to an ELB. Must be created in AWS first.
+
+        | *Default*: ``[]``
+
+        | *Type*: List of strings
+
+        | *Example*:
+
+            ::
+
+                "backend_policies": ["WebSocket-Proxy-Protocol"]
+
 ``ports`` *Example*
 ^^^^^^^^^^^^^^^^^^^
 

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -262,21 +262,15 @@ Defines ELB listeners. Expects a list of listeners.
 
     ``listener_policies`` : A list of listener policies to associate to an ELB. Must be created in AWS first.
 
-        | *Default*: `null`
+        | *Default*: ``[]``
 
         | *Type*: List of strings
 
     ``backend_policies`` : A list of backend server policies to associate to an ELB. Must be created in AWS first.
 
-        | *Default*: `null`
-
+        | *Default*: ``[]``
         | *Type*: List of strings
-
-        | *Example*:
-
-            ::
-
-                "backend_policies": ["WebSocket-Proxy-Protocol"]
+        | *Example*: ``["WebSocket-Proxy-Protocol"]```
 
 ``ports`` *Example*
 ^^^^^^^^^^^^^^^^^^^
@@ -295,7 +289,8 @@ Defines ELB listeners. Expects a list of listeners.
         {
           "certificate": "my_cert",
           "instance": "HTTP:8443",
-          "loadbalancer": "HTTPS:443"
+          "loadbalancer": "HTTPS:443",
+          "listener_policies": ["MyExamplePolicy"]
         }
       ]
 

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -262,13 +262,13 @@ Defines ELB listeners. Expects a list of listeners.
 
     ``listener_policies`` : A list of listener policies to associate to an ELB. Must be created in AWS first.
 
-        | *Default*: ``[]``
+        | *Default*: `null`
 
         | *Type*: List of strings
 
     ``backend_policies`` : A list of backend server policies to associate to an ELB. Must be created in AWS first.
 
-        | *Default*: ``[]``
+        | *Default*: `null`
 
         | *Type*: List of strings
 

--- a/_docs/infra_assumptions.rst
+++ b/_docs/infra_assumptions.rst
@@ -9,7 +9,7 @@ Spinnaker
 ---------
 
 - Foremast assumes that Spinnaker is already setup. Please see the `Spinnaker documentation`_ for assistance
-- Requires connectivity to the Gate component of Spinnaker. Foremast does not support authentication on Gate (yet).
+- Requires connectivity to the Gate component of Spinnaker. Foremast also supports x509 authentication on Gate.
 - Assumes AWS EBS is used for Packer bakes in Spinnaker Rosco
 
 

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -158,18 +158,15 @@ class SpinnakerELB:
         env = boto3.session.Session(profile_name=self.env, region_name=self.region)
         elbclient = env.client('elb')
 
-        #Attach backend server policies to created ELB
+        # Attach backend server policies to created ELB
         for job in json.loads(json_data)['job']:
             for listener in job['listeners']:
-                policies = []
                 instance_port = listener['internalPort']
                 if listener['backendPolicies']:
-                    policies.extend(listener['backendPolicies'])
-                if policies:
-                    log.info("Adding backend server policies: %s", policies)
+                    log.info("Adding backend server policies: %s", listener['backendPolicies'])
                     elbclient.set_load_balancer_policies_for_backend_server(LoadBalancerName=self.app,
                                                                             InstancePort=instance_port,
-                                                                            PolicyNames=policies)
+                                                                            PolicyNames=listener['backendPolicies'])
 
 
     def add_stickiness(self):

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -162,11 +162,12 @@ class SpinnakerELB:
         for job in json.loads(json_data)['job']:
             for listener in job['listeners']:
                 instance_port = listener['internalPort']
-                if listener['backendPolicies']:
-                    log.info("Adding backend server policies: %s", listener['backendPolicies'])
+                backend_policy_list = listener['backendPolicies']
+                if backend_policy_list:
+                    log.info("Adding backend server policies: %s", backend_policy_list)
                     elbclient.set_load_balancer_policies_for_backend_server(LoadBalancerName=self.app,
                                                                             InstancePort=instance_port,
-                                                                            PolicyNames=listener['backendPolicies'])
+                                                                            PolicyNames=backend_policy_list)
 
 
     def add_stickiness(self):

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -143,7 +143,7 @@ class SpinnakerELB:
                 if stickiness.get(ext_port):
                     policies.append(stickiness.get(ext_port))
                 if policies:
-                    log.info("Adding policies: %s", policies)
+                    log.info("Adding listener policies: %s", policies)
                     elbclient.set_load_balancer_policies_of_listener(LoadBalancerName=self.app,
                                                                      LoadBalancerPort=ext_port,
                                                                      PolicyNames=policies)
@@ -162,11 +162,11 @@ class SpinnakerELB:
         for job in json.loads(json_data)['job']:
             for listener in job['listeners']:
                 policies = []
-                instance_port = listener['instancePort']
+                instance_port = listener['internalPort']
                 if listener['backendPolicies']:
                     policies.extend(listener['backendPolicies'])
                 if policies:
-                    log.info("Adding policies: %s", policies)
+                    log.info("Adding backend server policies: %s", policies)
                     elbclient.set_load_balancer_policies_for_backend_server(LoadBalancerName=self.app,
                                                                             InstancePort=instance_port,
                                                                             PolicyNames=policies)

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -69,7 +69,8 @@ def format_listeners(elb_settings=None, env='dev'):
                     'internalPort': 8080,
                     'internalProtocol': 'HTTP',
                     'sslCertificateId': None,
-                    'listenerPolicies': []
+                    'listenerPolicies': [],
+                    'backendPolicies': []
                 },
                 ...
             ]
@@ -88,6 +89,8 @@ def format_listeners(elb_settings=None, env='dev'):
             lb_proto, lb_port = listener['loadbalancer'].split(':')
             i_proto, i_port = listener['instance'].split(':')
             listener_policies = listener.get('policies', [])
+            listener_policies += listener.get('listenerpolicies', [])
+            backend_policies = listener.get('backendpolicies', [])
 
             elb_data = {
                 'externalPort': int(lb_port),
@@ -96,17 +99,21 @@ def format_listeners(elb_settings=None, env='dev'):
                 'internalProtocol': i_proto.upper(),
                 'sslCertificateId': cert_name,
                 'listenerPolicies': listener_policies,
+                'backendPolicies': backend_policies,
             }
 
             listeners.append(elb_data)
     else:
+        listener_policies = elb_settings['policies']
+        listener_policies += elb_settings['listenerpolicies']
         listeners = [{
             'externalPort': int(elb_settings['lb_port']),
             'externalProtocol': elb_settings['lb_proto'],
             'internalPort': int(elb_settings['i_port']),
             'internalProtocol': elb_settings['i_proto'],
             'sslCertificateId': elb_settings['certificate'],
-            'listenerPolicies': elb_settings['policies'],
+            'listenerPolicies': listener_policies,
+            'backendPolicies': elb_settings['backendpolicies'],
         }]
 
     for listener in listeners:
@@ -114,7 +121,8 @@ def format_listeners(elb_settings=None, env='dev'):
                  'loadbalancer %(externalProtocol)s:%(externalPort)d\n'
                  'instance %(internalProtocol)s:%(internalPort)d\n'
                  'certificate: %(sslCertificateId)s\n'
-                 'listenerpolicies: %(listenerPolicies)s', listener)
+                 'listenerpolicies: %(listenerPolicies)s\n')
+                 'backendpolicies: %(backendPolicies)s', listener)
     return listeners
 
 

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -106,6 +106,8 @@ def format_listeners(elb_settings=None, env='dev'):
     else:
         listener_policies = elb_settings.get('policies', [])
         listener_policies += elb_settings.get('listener_policies', [])
+        backend_policies = elb_settings.get('backend_policies', [])
+
         listeners = [{
             'externalPort': int(elb_settings['lb_port']),
             'externalProtocol': elb_settings['lb_proto'],
@@ -113,7 +115,7 @@ def format_listeners(elb_settings=None, env='dev'):
             'internalProtocol': elb_settings['i_proto'],
             'sslCertificateId': elb_settings['certificate'],
             'listenerPolicies': listener_policies,
-            'backendPolicies': elb_settings['backend_policies'],
+            'backendPolicies': backend_policies,
         }]
 
     for listener in listeners:

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -104,8 +104,8 @@ def format_listeners(elb_settings=None, env='dev'):
 
             listeners.append(elb_data)
     else:
-        listener_policies = elb_settings['policies']
-        listener_policies += elb_settings['listener_policies']
+        listener_policies = elb_settings.get('policies', [])
+        listener_policies += elb_settings.get('listener_policies', [])
         listeners = [{
             'externalPort': int(elb_settings['lb_port']),
             'externalProtocol': elb_settings['lb_proto'],

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -89,8 +89,8 @@ def format_listeners(elb_settings=None, env='dev'):
             lb_proto, lb_port = listener['loadbalancer'].split(':')
             i_proto, i_port = listener['instance'].split(':')
             listener_policies = listener.get('policies', [])
-            listener_policies += listener.get('listenerpolicies', [])
-            backend_policies = listener.get('backendpolicies', [])
+            listener_policies += listener.get('listener_policies', [])
+            backend_policies = listener.get('backend_policies', [])
 
             elb_data = {
                 'externalPort': int(lb_port),
@@ -105,7 +105,7 @@ def format_listeners(elb_settings=None, env='dev'):
             listeners.append(elb_data)
     else:
         listener_policies = elb_settings['policies']
-        listener_policies += elb_settings['listenerpolicies']
+        listener_policies += elb_settings['listener_policies']
         listeners = [{
             'externalPort': int(elb_settings['lb_port']),
             'externalProtocol': elb_settings['lb_proto'],
@@ -113,7 +113,7 @@ def format_listeners(elb_settings=None, env='dev'):
             'internalProtocol': elb_settings['i_proto'],
             'sslCertificateId': elb_settings['certificate'],
             'listenerPolicies': listener_policies,
-            'backendPolicies': elb_settings['backendpolicies'],
+            'backendPolicies': elb_settings['backend_policies'],
         }]
 
     for listener in listeners:
@@ -121,8 +121,8 @@ def format_listeners(elb_settings=None, env='dev'):
                  'loadbalancer %(externalProtocol)s:%(externalPort)d\n'
                  'instance %(internalProtocol)s:%(internalPort)d\n'
                  'certificate: %(sslCertificateId)s\n'
-                 'listenerpolicies: %(listenerPolicies)s\n')
-                 'backendpolicies: %(backendPolicies)s', listener)
+                 'listener_policies: %(listenerPolicies)s\n'
+                 'backend_policies: %(backendPolicies)s', listener)
     return listeners
 
 

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -24,6 +24,8 @@
     "elb": {
         "certificate": null,
         "policies": null,
+        "listener_policies": null,
+        "backend_policies": null,
         "health": {
             "interval": 20,
             "threshold": 2,

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -62,6 +62,8 @@ def test_elb_format_listeners(mock_creds):
         'lb_port': 80,
         'lb_proto': 'HTTP',
         'policies': None,
+        'listener_policies': None,
+        'backend_policies': None,
     }
     generated = [{
         'externalPort': 80,
@@ -70,6 +72,7 @@ def test_elb_format_listeners(mock_creds):
         'internalProtocol': 'HTTP',
         'sslCertificateId': None,
         'listenerPolicies': None,
+        'backendPolicies': None,
     }]
 
     # check defaults
@@ -84,6 +87,7 @@ def test_elb_format_listeners(mock_creds):
         'internalProtocol': 'HTTP',
         'sslCertificateId': None,
         'listenerPolicies': [],
+        'backendPolicies': [],
     }]
 
     # check ports
@@ -101,6 +105,7 @@ def test_elb_format_listeners(mock_creds):
         'internalProtocol': 'HTTP',
         'sslCertificateId': 'arn:aws:iam::0100:server-certificate/kerby',
         'listenerPolicies': [],
+        'backendPolicies': [],
     })
 
     # check certificate

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -61,9 +61,9 @@ def test_elb_format_listeners(mock_creds):
         'i_proto': 'HTTP',
         'lb_port': 80,
         'lb_proto': 'HTTP',
-        'policies': None,
-        'listener_policies': None,
-        'backend_policies': None,
+        'policies': [],
+        'listener_policies': [],
+        'backend_policies': [],
     }
     generated = [{
         'externalPort': 80,
@@ -71,8 +71,8 @@ def test_elb_format_listeners(mock_creds):
         'internalPort': 8080,
         'internalProtocol': 'HTTP',
         'sslCertificateId': None,
-        'listenerPolicies': None,
-        'backendPolicies': None,
+        'listenerPolicies': [],
+        'backendPolicies': [],
     }]
 
     # check defaults
@@ -123,12 +123,13 @@ def test_elb_format_cert_name():
     assert compiled_cert == format_cert_name(account='dev', certificate='mycert1')
 
 
+@mock.patch.object(SpinnakerELB, 'add_backend_policy')
 @mock.patch.object(SpinnakerELB, 'add_listener_policy')
 @mock.patch('foremast.elb.create_elb.check_task')
 @mock.patch('foremast.elb.create_elb.post_task')
 @mock.patch.object(SpinnakerELB, 'make_elb_json', return_value={})
 @mock.patch('foremast.elb.create_elb.get_properties')
-def test_elb_create_elb(mock_get_properties, mock_elb_json, mock_post_task, mock_check_task, mock_listener_policy):
+def test_elb_create_elb(mock_get_properties, mock_elb_json, mock_post_task, mock_check_task, mock_listener_policy, mock_backend_policy):
     """Test SpinnakerELB create_elb method"""
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.create_elb()
@@ -216,4 +217,4 @@ def test_elb_add_backend_policy(mock_get_properties, mock_boto3_session):
 
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_backend_policy(json.dumps(json_data))
-    assert client.set_load_balancer_policies_of_listener.called
+    assert client.set_load_balancer_policies_for_backend_server.called

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -190,3 +190,25 @@ def test_elb_add_listener_policy(mock_get_properties, mock_boto3_session):
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_listener_policy(json.dumps(json_data))
     assert client.set_load_balancer_policies_of_listener.called
+
+@mock.patch('foremast.elb.create_elb.boto3.session.Session')
+@mock.patch('foremast.elb.create_elb.get_properties')
+def test_elb_add_backend_policy(mock_get_properties, mock_boto3_session):
+
+    json_data = {
+       'job': [
+            {
+                'listeners': [
+                    {
+                        'internalPort': 80,
+                        'backendPolicies': ['policy_name']
+                    },
+                ],
+            }
+       ],
+    }
+    client = mock_boto3_session.return_value.client.return_value
+
+    elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
+    elb.add_backend_policy(json.dumps(json_data))
+    assert client.set_load_balancer_policies_of_listener.called

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -178,14 +178,17 @@ def test_elb_make_elb_json(mock_get_properties, mock_get_subnets, mock_format_li
 @mock.patch('foremast.elb.create_elb.boto3.session.Session')
 @mock.patch('foremast.elb.create_elb.get_properties')
 def test_elb_add_listener_policy(mock_get_properties, mock_boto3_session):
+    test_app = 'myapp'
+    test_port = 80
+    test_policy_list = ['policy_name']
 
     json_data = {
        'job': [
             {
                 'listeners': [
                     {
-                        'externalPort': 80,
-                        'listenerPolicies': ['policy_name']
+                        'externalPort': test_port,
+                        'listenerPolicies': test_policy_list
                     },
                 ],
             }
@@ -195,19 +198,22 @@ def test_elb_add_listener_policy(mock_get_properties, mock_boto3_session):
 
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_listener_policy(json.dumps(json_data))
-    client.set_load_balancer_policies_of_listener.assert_called_with(LoadBalancerName='myapp', LoadBalancerPort=80, PolicyNames=['policy_name'])
+    client.set_load_balancer_policies_of_listener.assert_called_with(LoadBalancerName=test_app, LoadBalancerPort=test_port, PolicyNames=test_policy_list)
 
 @mock.patch('foremast.elb.create_elb.boto3.session.Session')
 @mock.patch('foremast.elb.create_elb.get_properties')
 def test_elb_add_backend_policy(mock_get_properties, mock_boto3_session):
+    test_app = 'myapp'
+    test_port = 80
+    test_policy_list = ['policy_name']
 
     json_data = {
        'job': [
             {
                 'listeners': [
                     {
-                        'internalPort': 80,
-                        'backendPolicies': ['policy_name']
+                        'internalPort': test_port,
+                        'backendPolicies': test_policy_list
                     },
                 ],
             }
@@ -217,4 +223,4 @@ def test_elb_add_backend_policy(mock_get_properties, mock_boto3_session):
 
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_backend_policy(json.dumps(json_data))
-    client.set_load_balancer_policies_for_backend_server.assert_called_with(InstancePort=80, LoadBalancerName='myapp', PolicyNames=['policy_name'])
+    client.set_load_balancer_policies_for_backend_server.assert_called_with(LoadBalancerName=test_app, InstancePort=test_port, PolicyNames=test_policy_list)

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -195,7 +195,7 @@ def test_elb_add_listener_policy(mock_get_properties, mock_boto3_session):
 
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_listener_policy(json.dumps(json_data))
-    assert client.set_load_balancer_policies_of_listener.called
+    client.set_load_balancer_policies_of_listener.assert_called_with(LoadBalancerName='myapp', LoadBalancerPort=80, PolicyNames=['policy_name'])
 
 @mock.patch('foremast.elb.create_elb.boto3.session.Session')
 @mock.patch('foremast.elb.create_elb.get_properties')
@@ -217,4 +217,4 @@ def test_elb_add_backend_policy(mock_get_properties, mock_boto3_session):
 
     elb = SpinnakerELB(app='myapp', env='dev', region='us-east-1')
     elb.add_backend_policy(json.dumps(json_data))
-    assert client.set_load_balancer_policies_for_backend_server.called
+    client.set_load_balancer_policies_for_backend_server.assert_called_with(InstancePort=80, LoadBalancerName='myapp', PolicyNames=['policy_name'])


### PR DESCRIPTION
- Needed for legacy support for WebSockets where they need to pass to backend systems through ProxyProtocol
- Cleaned up naming of 'policies'; to be specific to 'listenerpolicies' in the foremast config, but in order to not break exisiting functionality, merged policies + listenerpolicies