### PR TITLE
Support for modifying ASG Grace Period

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -124,12 +124,16 @@ ASG Health check type (EC2 or ELB)
        - ``"ELB"``
        - ``"EC2"``
 
-``hc_grace_period``
+``app_grace_period``
 ************
 
-ASG health check grace period to delay sending of health check requests
+App specific health check grace period (added onto default ASG healthcheck grace period) to delay sending 
+of health check requests. This is useful in the event your application takes longer to boot than the 
+default hc_grace_period defined in templates. For example, hc_grace_period may be 180 seconds, but an app 
+may need a variable amount of time to boot (say 30 seconds extra). This will add 180 + 30 to calculate 
+the overall hc_grace_period of 210 seconds.
 
-    | *Default*: ``180``
+    | *Default*: ``0``
     | *Units*: Seconds
 
 ``max_inst``

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -124,6 +124,14 @@ ASG Health check type (EC2 or ELB)
        - ``"ELB"``
        - ``"EC2"``
 
+``hc_grace_period``
+************
+
+ASG health check grace period to delay sending of health check requests
+
+    | *Default*: ``180``
+    | *Units*: Seconds
+
 ``max_inst``
 *************
 

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -140,7 +140,8 @@ def construct_pipeline_block(env='',
     # Aggregate the default grace period, plus the exposed app_grace_period
     # to allow per repo extension of asg healthcheck grace period
     hc_grace_period = data['asg'].get('hc_grace_period')
-    hc_grace_period += data['asg'].get('app_grace_period')
+    app_grace_period = data['asg'].get('app_grace_period')
+    grace_period = hc_grace_period + app_grace_period
 
     data['app'].update({
         'appname': gen_app_name,
@@ -160,7 +161,7 @@ def construct_pipeline_block(env='',
 
     data['asg'].update({
         'hc_type': data['asg'].get('hc_type').upper(),
-        'hc_grace_period': hc_grace_period,
+        'hc_grace_period': grace_period,
         'provider_healthcheck': json.dumps(health_checks.providers),
         'enable_public_ips': json.dumps(settings['asg']['enable_public_ips']),
         'has_provider_healthcheck': health_checks.has_healthcheck,

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -137,6 +137,11 @@ def construct_pipeline_block(env='',
         data['asg'].update({'hc_type': 'EC2'})
         LOG.info('Switching health check type to: EC2')
 
+    # Aggregate the default grace period, plus the exposed app_grace_period
+    # to allow per repo extension of asg healthcheck grace period
+    hc_grace_period = data['asg'].get('hc_grace_period')
+    hc_grace_period += data['asg'].get('app_grace_period')
+
     data['app'].update({
         'appname': gen_app_name,
         'repo_name': generated.repo,
@@ -155,6 +160,7 @@ def construct_pipeline_block(env='',
 
     data['asg'].update({
         'hc_type': data['asg'].get('hc_type').upper(),
+        'hc_grace_period': hc_grace_period,
         'provider_healthcheck': json.dumps(health_checks.providers),
         'enable_public_ips': json.dumps(settings['asg']['enable_public_ips']),
         'has_provider_healthcheck': health_checks.has_healthcheck,

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -13,6 +13,7 @@
     },
     "asg": {
         "hc_type": "ELB",
+        "hc_grace_period": 180,
         "max_inst": 3,
         "min_inst": 1,
         "subnet_purpose": "internal",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -14,6 +14,7 @@
     "asg": {
         "hc_type": "ELB",
         "hc_grace_period": 180,
+        "app_grace_period": 0,
         "max_inst": 3,
         "min_inst": 1,
         "subnet_purpose": "internal",

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -20,7 +20,7 @@
           "targetHealthyDeployPercentage": 100,
           "cooldown": 10,
           "healthCheckType": "{{ data.asg.hc_type }}",
-          "healthCheckGracePeriod": "180",
+          "healthCheckGracePeriod": "{{ data.asg.hc_grace_period }}",
           {% if data.asg.has_provider_healthcheck -%}
           "interestingHealthProviderNames": {{ data.asg.provider_healthcheck }},
           {%- endif %}


### PR DESCRIPTION
This will allow users to set their ASG grace period if their application takes longer to boot up than usual. We should consider splitting up into two variables that ultimately calculate hc_grace_period; os_grace_period and app_grace_period.

os_grace_period is usually best known by sysadmins (in regards to average boot time of base operating systems). Development teams would know how long it takes for their container to spin up. Ideally, os_grace_period should be hard coded and maintained by admins to the default time it takes to boot up a raw vanilla server. Devs should then be exposed to enabling only app_grace_period; since they see startup times in their logs.

os_grace_period: 180s
app_grace_period: 40s
hc_grace_period: 220s