### PR TITLE
Format config check logging

### DIFF
--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -51,7 +51,7 @@ def validate_key_values(config_handle, section, key, default=None):
     """
     try:
         config_handle.add_section(section)
-        LOG.warning('Section missing from configurations: [%s]', section)
+        LOG.info('Section missing from configurations: [%s]', section)
     except DuplicateSectionError:
         pass
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -104,7 +104,7 @@ def find_config():
     cfg_file = configurations.read(config_locations)
 
     if not cfg_file:
-        LOG.warning('No configuration found in the following locations:\n\n%s\n', '\n'.join(config_locations))
+        LOG.warning('No configuration found in the following locations:\n%s', '\n'.join(config_locations))
 
     return configurations
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -31,7 +31,11 @@ from configparser import ConfigParser, DuplicateSectionError
 from os.path import expanduser, expandvars
 
 LOG = logging.getLogger(__name__)
+LOGGING_FORMAT = '%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s'
+SHORT_LOGGING_FORMAT = '[%(levelname)s] %(message)s'
 
+logging.basicConfig(format=LOGGING_FORMAT)
+logging.getLogger(__package__.split('.')[0]).setLevel(logging.INFO)
 
 def validate_key_values(config_handle, section, key, default=None):
     """Warn when *key* is missing from configuration *section*.
@@ -132,6 +136,3 @@ HEADERS = {
     'content-type': 'application/json',
     'user-agent': 'foremast',
 }
-
-LOGGING_FORMAT = '%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s'
-SHORT_LOGGING_FORMAT = '[%(levelname)s] %(message)s'


### PR DESCRIPTION
Update config logging format so it matches the rest of the output.

**Current**
```
No configuration found in the following locations:

/etc/foremast/foremast.cfg
/home/saviles/.foremast/foremast.cfg
./.foremast/foremast.cfg

Section missing from configurations: [base]
[base] missing key "gate_api_url", using None.
[base] missing key "git_url", using None.
[base] missing key "domain", using 'example.com'.
[base] missing key "envs", using ''.
[base] missing key "regions", using ''.
[base] missing key "types", using 'ec2,lambda,s3'.
[base] missing key "templates_path", using None.
[base] missing key "ami_json_url", using None.
[base] missing key "default_ec2_securitygroups", using ''.
[base] missing key "default_elb_securitygroups", using ''.
Section missing from configurations: [credentials]
[credentials] missing key "gitlab_token", using None.
[credentials] missing key "slack_token", using None.
Section missing from configurations: [whitelists]
[whitelists] missing key "asg_whitelist", using ''.
[base] missing key "gate_client_cert", using ''.
[base] missing key "gate_ca_bundle", using ''.
2017-03-31 23:33:51,568 [INFO] foremast.configs.prepare_configs:process_runway_configs:80 - Processing application.json files from local directory "/tmp/broker/runway/".
2017-03-31 23:33:51,569 [INFO] foremast.utils.lookups:local_file:103 - Retrieving "application-master-.json" from "/tmp/broker/runway/".
2017-03-31 23:33:51,569 [WARNING] foremast.utils.lookups:local_file:113 - File missing "/tmp/broker/runway/application-master-.json".
2017-03-31 23:33:51,569 [CRITICAL] foremast.configs.prepare_configs:process_runway_configs:90 - Application configuration not available for .
2017-03-31 23:33:51,569 [INFO] foremast.configs.prepare_configs:process_runway_configs:93 - Processing pipeline.json from local directory
2017-03-31 23:33:51,569 [INFO] foremast.utils.lookups:local_file:103 - Retrieving "pipeline.json" from "/tmp/broker/runway/".
2017-03-31 23:33:51,569 [WARNING] foremast.utils.lookups:local_file:113 - File missing "/tmp/broker/runway/pipeline.json".
2017-03-31 23:33:51,569 [WARNING] foremast.configs.prepare_configs:process_runway_configs:98 - Unable to process pipeline.json. Using defaults.
2017-03-31 23:33:51,571 [INFO] foremast.utils.templates:get_template:76 - Rendering template /home/saviles/git/foremast/src/foremast/utils/../templates/configs/pipeline.json.j2
2017-03-31 23:33:51,572 [INFO] foremast.configs.outputs:write_variables:110 - Appending variables to /tmp/test.
2017-03-31 23:33:51,572 [INFO] foremast.configs.outputs:write_variables:114 - Writing sourceable variables to /tmp/test.exports.
2017-03-31 23:33:51,572 [INFO] foremast.configs.outputs:write_variables:119 - Writing JSON to /tmp/test.json.

```

**After**
```
2017-03-31 23:29:16,571 [WARNING] foremast.consts:find_config:107 - No configuration found in the following locations:
/etc/foremast/foremast.cfg
/home/saviles/.foremast/foremast.cfg
./.foremast/foremast.cfg
2017-03-31 23:29:16,571 [INFO] foremast.consts:validate_key_values:54 - Section missing from configurations: [base]
2017-03-31 23:29:16,571 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "gate_api_url", using None.
2017-03-31 23:29:16,571 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "git_url", using None.
2017-03-31 23:29:16,571 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "domain", using 'example.com'.
2017-03-31 23:29:16,571 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "envs", using ''.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "regions", using ''.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "types", using 'ec2,lambda,s3'.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "templates_path", using None.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "ami_json_url", using None.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "default_ec2_securitygroups", using ''.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "default_elb_securitygroups", using ''.
2017-03-31 23:29:16,572 [INFO] foremast.consts:validate_key_values:54 - Section missing from configurations: [credentials]
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [credentials] missing key "gitlab_token", using None.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [credentials] missing key "slack_token", using None.
2017-03-31 23:29:16,572 [INFO] foremast.consts:validate_key_values:54 - Section missing from configurations: [whitelists]
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [whitelists] missing key "asg_whitelist", using ''.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "gate_client_cert", using ''.
2017-03-31 23:29:16,572 [WARNING] foremast.consts:validate_key_values:63 - [base] missing key "gate_ca_bundle", using ''.
2017-03-31 23:29:16,692 [INFO] foremast.configs.prepare_configs:process_runway_configs:80 - Processing application.json files from local directory "/tmp/broker/runway/".
2017-03-31 23:29:16,693 [INFO] foremast.utils.lookups:local_file:103 - Retrieving "application-master-.json" from "/tmp/broker/runway/".
2017-03-31 23:29:16,693 [WARNING] foremast.utils.lookups:local_file:113 - File missing "/tmp/broker/runway/application-master-.json".
2017-03-31 23:29:16,693 [CRITICAL] foremast.configs.prepare_configs:process_runway_configs:90 - Application configuration not available for .
2017-03-31 23:29:16,693 [INFO] foremast.configs.prepare_configs:process_runway_configs:93 - Processing pipeline.json from local directory
2017-03-31 23:29:16,693 [INFO] foremast.utils.lookups:local_file:103 - Retrieving "pipeline.json" from "/tmp/broker/runway/".
2017-03-31 23:29:16,693 [WARNING] foremast.utils.lookups:local_file:113 - File missing "/tmp/broker/runway/pipeline.json".
2017-03-31 23:29:16,693 [WARNING] foremast.configs.prepare_configs:process_runway_configs:98 - Unable to process pipeline.json. Using defaults.
2017-03-31 23:29:16,695 [INFO] foremast.utils.templates:get_template:76 - Rendering template /home/saviles/git/foremast/src/foremast/utils/../templates/configs/pipeline.json.j2
2017-03-31 23:29:16,696 [INFO] foremast.configs.outputs:write_variables:110 - Appending variables to /tmp/test.
2017-03-31 23:29:16,696 [INFO] foremast.configs.outputs:write_variables:114 - Writing sourceable variables to /tmp/test.exports.
2017-03-31 23:29:16,696 [INFO] foremast.configs.outputs:write_variables:119 - Writing JSON to /tmp/test.json.
```
