### PR TITLE
Enabled custom SSH key pairs

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -31,13 +31,6 @@ Describes the application.
 
     | *Default*: ``null``
 
-``app_ssh_key``
-*******************
-
-SSH key that your EC2 instances will use. Must already be created in AWS.
-
-    | *Default*: ``"{{ account }}_access"`` - {{ account }} being the AWS account in the configuration name
-
 ``eureka_enabled``
 ***********************
 
@@ -151,6 +144,13 @@ Minimum number of instances your auto-scaling group should have at all times. Th
 
     | *Type*: int
     | *Default*: ``1``
+
+``ssh_keypair``
+*******************
+
+SSH key that your EC2 instances will use. Must already be created in AWS.
+
+    | *Default*: ``"{{ account }}_{{ region }}_default"`` - {{ account }} being the AWS account in the configuration name
 
 ``subnet_purpose``
 ******************

--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -148,7 +148,7 @@ Minimum number of instances your auto-scaling group should have at all times. Th
 ``ssh_keypair``
 *******************
 
-SSH key that your EC2 instances will use. Must already be created in AWS.
+SSH key that your EC2 instances will use. Must already be created in AWS. This replaces the non-functional and deprecated app_ssh_key configuration key.
 
     | *Default*: ``"{{ account }}_{{ region }}_default"`` - {{ account }} being the AWS account in the configuration name
 

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -143,6 +143,8 @@ def construct_pipeline_block(env='',
     app_grace_period = data['asg'].get('app_grace_period')
     grace_period = hc_grace_period + app_grace_period
     
+    # TODO: Migrate the naming logic to an external library to make it easier
+    #       to update in the future. Gogo-Utils looks like a good candidate
     ssh_keypair = data['asg'].get('ssh_keypair', None)
     LOG.info('SSH keypair ({0}) used'.format(ssh_keypair))
     if not ssh_keypair:

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -142,6 +142,12 @@ def construct_pipeline_block(env='',
     hc_grace_period = data['asg'].get('hc_grace_period')
     app_grace_period = data['asg'].get('app_grace_period')
     grace_period = hc_grace_period + app_grace_period
+    
+    ssh_keypair = data['asg'].get('ssh_keypair', None)
+    LOG.info('SSH keypair ({0}) used'.format(ssh_keypair))
+    if not ssh_keypair:
+        ssh_keypair = '{0}_{1}_default'.format(env, region)
+    LOG.info('SSH keypair ({0}) used'.format(ssh_keypair))
 
     data['app'].update({
         'appname': gen_app_name,
@@ -162,6 +168,7 @@ def construct_pipeline_block(env='',
     data['asg'].update({
         'hc_type': data['asg'].get('hc_type').upper(),
         'hc_grace_period': grace_period,
+        'ssh_keypair': ssh_keypair,
         'provider_healthcheck': json.dumps(health_checks.providers),
         'enable_public_ips': json.dumps(settings['asg']['enable_public_ips']),
         'has_provider_healthcheck': health_checks.has_healthcheck,

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -1,7 +1,6 @@
 {
     "app": {
         "app_description": null,
-        "app_ssh_key": "{{ env }}_access",
         "email": null,
         "eureka_enabled": false,
         "instance_profile": "{{ profile }}",
@@ -17,6 +16,7 @@
         "app_grace_period": 0,
         "max_inst": 3,
         "min_inst": 1,
+        "ssh_keypair": null,
         "subnet_purpose": "internal",
         "enable_public_ips": null,
         "provider_healthcheck": {

--- a/src/foremast/templates/pipeline/stage-deploy.json.j2
+++ b/src/foremast/templates/pipeline/stage-deploy.json.j2
@@ -31,7 +31,7 @@
             "Default"
           ],
           "availabilityZones": {{ data.app.az_dict }},
-          "keyPair": "{{ data.app.environment }}_{{ data.app.region }}_default",
+          "keyPair": "{{ data.asg.ssh_keypair }}",
           "suspendedProcesses": [],
           "securityGroups": {{ data.app.instance_security_groups }},
           "tags": {


### PR DESCRIPTION
We had an unused app_ssh_key variable in our configs, I moved the key pair to the asg block seeing as that is where it is implemented. Renamed the variable to ssh_keypair.