### PR TITLE
Feature/shared s3

### DIFF
--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -148,3 +148,7 @@ class PrimaryDNSRecordNotFound(ForemastError):
 class S3ArtifactNotFound(ForemastError):
     """Could not find Artifact to upload to S3"""
     pass
+
+class S3SharedBucketNotFound(ForemastError):
+    """Shared S3 Bucket does not exist"""
+    pass

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -46,7 +46,7 @@ class S3Apps(object):
         self.properties = get_properties(prop_path)
         self.s3props = self.properties[self.env]['s3']
 
-        if self.s3props.get('shared_bucket_master')
+        if self.s3props.get('shared_bucket_master'):
             self.bucket = self.generated.shared_s3_app_bucket()
         elif self.s3props.get('shared_bucket_target'):
             shared_app = self.s3props['shared_bucket_target']
@@ -118,5 +118,5 @@ class S3Apps(object):
         try:
             s3.get_bucket_location(Bucket=self.bucket)
             return True
-        except ClientError
+        except ClientError:
             return False

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -41,9 +41,18 @@ class S3Apps(object):
         boto_sess = boto3.session.Session(profile_name=env)
         self.s3client = boto_sess.client('s3')
         self.generated = get_details(app=app, env=env)
-        self.bucket = self.generated.s3_app_bucket()
         self.properties = get_properties(prop_path)
         self.s3props = self.properties[self.env]['s3']
+
+        if self.s3props.get('shared_bucket_master')
+            self.bucket = self.generated.shared_s3_app_bucket()
+        elif self.s3props.get('shared_bucket_target'):
+            shared_app = self.s3props['shared_bucket_target'].split('/')
+            shared_formatted = '{}{}'.format(shared_app[1], shared_app[0])
+            newgenerated = get_details(app=formattedapp)
+            self.bucket = newgenerated.shared_s3_app_bucket()
+        else:
+            self.bucket = self.generated.s3_app_bucket()
 
     def create_bucket(self):
         """Creates or updates bucket based on app name"""

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -116,7 +116,7 @@ class S3Apps(object):
     def _bucket_exists(self):
         """Checks if the bucket exists"""
         try:
-            s3.get_bucket_location(Bucket=self.bucket)
+            self.s3client.get_bucket_location(Bucket=self.bucket)
             return True
         except ClientError:
             return False

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -102,16 +102,15 @@ class S3Apps(object):
         else:
             s3_endpoint = "{0}.s3-website-{1}.amazonaws.com".format(self.bucket, self.region)
 
-        bucket_dns = self.generated.dns()['global']
         zone_ids = get_dns_zone_ids(env=self.env, facing="public")
-        dns_kwargs = {'dns_name': bucket_dns,
+        dns_kwargs = {'dns_name': self.bucket,
                       'dns_name_aws': s3_endpoint,
                       'dns_ttl': self.properties[self.env]['dns']['ttl']}
 
         for zone_id in zone_ids:
             LOG.debug('zone_id: %s', zone_id)
             update_dns_zone_record(self.env, zone_id, **dns_kwargs)
-        LOG.info("Created DNS %s for Bucket", bucket_dns)
+        LOG.info("Created DNS %s for Bucket", self.bucket)
 
     def _bucket_exists(self):
         """Checks if the bucket exists"""

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -42,11 +42,22 @@ class S3Deployment(object):
         self.region = region
         self.artifact_path = artifact_path
         self.version = artifact_version
-        generated = get_details(app=app, env=env)
-        self.bucket = generated.s3_app_bucket()
         self.properties = get_properties(prop_path)
         self.s3props = self.properties[self.env]['s3']
-        self.s3path = self.s3props['path'].lstrip('/')
+        generated = get_details(app=app, env=env)
+
+        if self.s3props.get('shared_bucket_master'):
+            self.bucket = self.generated.shared_s3_app_bucket()
+            self.s3path = app
+        elif self.s3props.get('shared_bucket_target'):
+            shared_app = self.s3props['shared_bucket_target']
+            newgenerated = get_details(app=shared_app, env=env)
+            self.bucket = newgenerated.shared_s3_app_bucket()
+            self.s3path = app
+        else:
+            self.bucket = generated.s3_app_bucket()
+            self.s3path = self.s3props['path'].lstrip('/')
+
         self.s3_version_uri = ''
         self.s3_latest_uri = ''
         self.setup_pathing()

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -47,7 +47,7 @@ class S3Deployment(object):
         generated = get_details(app=app, env=env)
 
         if self.s3props.get('shared_bucket_master'):
-            self.bucket = self.generated.shared_s3_app_bucket()
+            self.bucket = generated.shared_s3_app_bucket()
             self.s3path = app
         elif self.s3props.get('shared_bucket_target'):
             shared_app = self.s3props['shared_bucket_target']

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -66,6 +66,7 @@
     },
     "lambda_triggers": [],
     "s3": {
+        "shared_bucket_master": false,
         "path": "/",
         "bucket_acl": "private",
         "bucket_policy": {},


### PR DESCRIPTION
Added the ability to specify a shared bucket for S3 deployments. Looks like the following:

Master Bucket Config:

 "s3": {
     "shared_bucket_master": true
     "bucket_acl": "private",
     "bucket_policy": $policy,
     "website": {
         "enabled": true,
     }
  } 

NonMaster Shared Bucket Config:

  "s3": {
    "shared_bucket_target": "$sharedappname"
  } 

This creates a bucket prefixed with `common` and then the nonmaster deploys to a path with appname in the shared bucket. 
