### PR TITLE
Fixed invalid app cookie stickiness policy names

### DIFF
--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -204,7 +204,8 @@ class SpinnakerELB:
                 policyname_tmp = "{0}-{1}-{2}-{3}"
                 if sticky_type == 'app':
                     cookiename = listener['stickiness']['cookie_name']
-                    policyname = policyname_tmp.format(self.app, sticky_type, externalport, cookiename)
+                    policy_key = cookiename.replace('.','')
+                    policyname = policyname_tmp.format(self.app, sticky_type, externalport, policy_key)
                     elbclient.create_app_cookie_stickiness_policy(LoadBalancerName=self.app,
                                                                   PolicyName=policyname,
                                                                   CookieName=cookiename)


### PR DESCRIPTION
Some JS libraries ship with dots by default in their cookie name, this at least strips it out.

This will fix @willkelleher report of default cookies from Express.