### PR TITLE
Hotfix/fix remunerate

### DIFF
--- a/src/foremast/pipeline/renumerate_stages.py
+++ b/src/foremast/pipeline/renumerate_stages.py
@@ -53,7 +53,7 @@ def renumerate_stages(pipeline):
             stage['refId'] = str(main_index)
         elif current_refId == 'branch':
             #increments a branch_index to account for multiple parrallel stages
-            if previous_refid == 'branch':
+            if previous_refId == 'branch':
                 branch_index += 1
             else:
                 branch_index = 0
@@ -62,8 +62,8 @@ def renumerate_stages(pipeline):
         elif current_refId == 'merge':
             # ToDo: Added logic to handle merge stages.
             pass
-        previous_refId = current_refId
 
+        previous_refId = current_refId
         LOG.debug('step=%(name)s\trefId=%(refId)s\t'
                   'requisiteStageRefIds=%(requisiteStageRefIds)s', stage)
 

--- a/src/foremast/pipeline/renumerate_stages.py
+++ b/src/foremast/pipeline/renumerate_stages.py
@@ -39,6 +39,9 @@ def renumerate_stages(pipeline):
     stages = pipeline['stages']
 
     main_index = 0
+    branch_index = 0
+    previous_refId = ''
+
     for stage in stages:
         current_refId = stage['refId'].lower()
         if current_refId == 'master':
@@ -49,11 +52,17 @@ def renumerate_stages(pipeline):
             main_index += 1
             stage['refId'] = str(main_index)
         elif current_refId == 'branch':
-            stage['refId'] = str(main_index*100)
+            #increments a branch_index to account for multiple parrallel stages
+            if previous_refid == 'branch':
+                branch_index += 1
+            else:
+                branch_index = 0
+            stage['refId'] = str((main_index*100)+branch_index)
             stage['requisiteStageRefIds'] = [str(main_index)]
         elif current_refId == 'merge':
             # ToDo: Added logic to handle merge stages.
             pass
+        previous_refId = current_refId
 
         LOG.debug('step=%(name)s\trefId=%(refId)s\t'
                   'requisiteStageRefIds=%(requisiteStageRefIds)s', stage)

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -8,7 +8,8 @@
         "lambda_environment": null,
         "lambda_memory": "128",
         "lambda_role": null,
-        "lambda_timeout": "30"
+        "lambda_timeout": "30",
+        "canary": false
     },
     "asg": {
         "hc_type": "ELB",

--- a/tests/pipeline/test_renumerate.py
+++ b/tests/pipeline/test_renumerate.py
@@ -1,7 +1,16 @@
+"""Test Stage renumerate logic."""
 from foremast.pipeline.renumerate_stages import renumerate_stages
 
 
 def test_basic():
+    """Should be sequential Stage IDs.
+    Examples:
+        Graphically:
+
+        .. code-block:: text
+
+            [ 1 ]-[ 2 ]-[ 3 ]
+    """
     pipeline = {
         'stages': [
             {
@@ -37,6 +46,18 @@ def test_basic():
 
 
 def test_branches():
+    """Test 'branch' Stages refer to correct 'master' level.
+
+    Examples:
+        Graphically:
+
+        .. code-block:: text
+
+            [ 1 ]-[ 2 ]-[ 3 ]-[ 4 ]
+                    L---[200]
+                    L---[201]
+                    L---[202]
+    """
     pipeline = {
         'stages': [
             {

--- a/tests/pipeline/test_renumerate.py
+++ b/tests/pipeline/test_renumerate.py
@@ -96,15 +96,15 @@ def test_branches():
             },
             {
                 'refId': '200',
-                'requisiteStageRefIds': ['1'],
+                'requisiteStageRefIds': ['2'],
             },
             {
                 'refId': '201',
-                'requisiteStageRefIds': ['1'],
+                'requisiteStageRefIds': ['2'],
             },
             {
                 'refId': '202',
-                'requisiteStageRefIds': ['1'],
+                'requisiteStageRefIds': ['2'],
             },
             {
                 'refId': '3',

--- a/tests/pipeline/test_renumerate.py
+++ b/tests/pipeline/test_renumerate.py
@@ -1,0 +1,99 @@
+from foremast.pipeline.renumerate_stages import renumerate_stages
+
+
+def test_basic():
+    pipeline = {
+        'stages': [
+            {
+                'refId': 'master',
+            },
+            {
+                'refId': 'master',
+            },
+            {
+                'refId': 'master',
+            },
+        ],
+    }
+
+    answer = {
+        'stages': [
+            {
+                'refId': '1',
+                'requisiteStageRefIds': [],
+            },
+            {
+                'refId': '2',
+                'requisiteStageRefIds': ['1'],
+            },
+            {
+                'refId': '3',
+                'requisiteStageRefIds': ['2'],
+            },
+        ],
+    }
+
+    assert renumerate_stages(pipeline) == answer
+
+
+def test_branches():
+    pipeline = {
+        'stages': [
+            {
+                'refId': 'master',
+            },
+            {
+                'refId': 'master',
+            },
+            {
+                'refId': 'branch',
+            },
+            {
+                'refId': 'branch',
+            },
+            {
+                'refId': 'branch',
+            },
+            {
+                'refId': 'master',
+            },
+            {
+                'refId': 'master',
+            },
+        ],
+    }
+
+    answer = {
+        'stages': [
+            {
+                'refId': '1',
+                'requisiteStageRefIds': [],
+            },
+            {
+                'refId': '2',
+                'requisiteStageRefIds': ['1'],
+            },
+            {
+                'refId': '200',
+                'requisiteStageRefIds': ['1'],
+            },
+            {
+                'refId': '201',
+                'requisiteStageRefIds': ['1'],
+            },
+            {
+                'refId': '202',
+                'requisiteStageRefIds': ['1'],
+            },
+            {
+                'refId': '3',
+                'requisiteStageRefIds': ['2'],
+            },
+            {
+                'refId': '4',
+                'requisiteStageRefIds': ['3'],
+            },
+        ],
+    }
+
+    assert renumerate_stages(pipeline) == answer


### PR DESCRIPTION
Fixed an issue where remunerate was not properly incrementing on multiple parallel/branch stages.

This fix now keeps track of a separate branch index  which is incremented if the previous generated stage was also a branch stage.


I also snuck in a fix for canary: false into the default templates 