### PR TITLE
[wip] added floor for scaling policy math to keep it all integers

### DIFF
--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -19,6 +19,7 @@ This module also creates an inverse policy for scaling down
 """
 import json
 import logging
+from math import floor
 import os
 
 import requests
@@ -75,8 +76,8 @@ class AutoScalingPolicy:
             template_kwargs['scalingAdjustment'] = 1
 
         elif scaling_type == 'scale_down':
-            self.settings['asg']['scaling_policy']['threshold'] = int(
-                self.settings['asg']['scaling_policy']['threshold']) * 0.5
+            cur_threshold = int(self.settings['asg']['scaling_policy']['threshold'])
+            self.settings['asg']['scaling_policy']['threshold'] = floor(cur_threshold * 0.5)
             template_kwargs['operation'] = 'decrease'
             template_kwargs['comparisonOperator'] = 'LessThanThreshold'
             template_kwargs['scalingAdjustment'] = -1


### PR DESCRIPTION
We have seen some issues with float/ints in this logic and so to eliminate this we will just use the floor and keep it all integers. 

#162 