### PR TITLE
refactor: Package version

### DIFF
--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -24,7 +24,7 @@
 import shlex
 import subprocess
 
-from pkg_resources import packaging
+import pkg_resources
 
 # -- General configuration ------------------------------------------------
 
@@ -72,19 +72,8 @@ author = 'Gogo DevOps'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-def tag_version():
-    """Generate version number from Git Tag, e.g. v2.0.0, v2.0.0-1."""
-    try:
-        recent_tag = subprocess.check_output(shlex.split('git describe --long'))
-    except subprocess.CalledProcessError:
-        recent_tag = b'v0.0-0-00000000'
-    tag, count, _ = recent_tag.decode().split('-')
-    raw_version = 'a'.join([tag, count]) if int(count) else tag
-    normalized_version = str(packaging.version.Version(raw_version))
-    return normalized_version
-
 # The full version, including alpha/beta/rc tags.
-release = tag_version()
+release = pkg_resources.get_distribution(project).version
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -21,7 +21,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import shlex
 import subprocess
 
 import pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -14,35 +14,21 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import shlex
-import subprocess
-
 from setuptools import find_packages, setup
-
-
-def tag_version():
-    """Generate version number from Git Tag, e.g. v2.0.0, v2.0.0-1."""
-    try:
-        recent_tag = subprocess.check_output(shlex.split('git describe --long'))
-    except subprocess.CalledProcessError:
-        recent_tag = b'v0.0-0-00000000'
-    tag, count, _ = recent_tag.decode().split('-')
-    version = 'a'.join([tag, count]) if int(count) else tag
-    return version
-
 
 with open('requirements.txt', 'rt') as reqs_file:
     reqs_list = reqs_file.readlines()
 
 setup(
     name='foremast',
-    version=tag_version(),
     description='Tools for creating infrastructure and Spinnaker Pipelines.',
     long_description=open('README.rst').read(),
     author='Gogo DevOps',
     author_email='ps-devops-tooling@example.com',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
+    setup_requires=['setuptools_scm'],
+    use_scm_version=True,
     install_requires=reqs_list,
     include_package_data=True,
     keywords="aws gogo infrastructure netflixoss python spinnaker",

--- a/src/foremast/__main__.py
+++ b/src/foremast/__main__.py
@@ -7,6 +7,7 @@ import os
 from . import runner, validate
 from .args import add_debug, add_env
 from .consts import LOGGING_FORMAT, SHORT_LOGGING_FORMAT
+from .version import print_version
 
 LOG = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ def main(manual_args=None):
         const=SHORT_LOGGING_FORMAT,
         default=LOGGING_FORMAT,
         help='Truncated logging format')
+    parser.add_argument('-v', '--version', action='store_true', help=print_version.__doc__)
 
     subparsers = parser.add_subparsers(title='Commands', description='Available activies')
 
@@ -106,6 +108,9 @@ def main(manual_args=None):
     logging.getLogger(package).setLevel(args.parsed.debug)
 
     LOG.debug('Arguments: %s', args)
+
+    if args.parsed.version:
+        args.parsed.func = print_version
 
     try:
         args.parsed.func(args)

--- a/src/foremast/version.py
+++ b/src/foremast/version.py
@@ -1,0 +1,19 @@
+"""Package version functions."""
+import pkg_resources
+
+
+def get_version():
+    """Retrieve package version."""
+    version = 'Not installed.'
+
+    try:
+        version = pkg_resources.get_distribution(__package__).version
+    except pkg_resources.DistributionNotFound:
+        pass
+
+    return version
+
+
+def print_version():
+    """Show package version."""
+    print(get_version())


### PR DESCRIPTION
Turns out, there was a hidden gem in https://setuptools.readthedocs.io/en/latest/setuptools.html#adding-support-for-revision-control-systems referring to a smart package, https://pypi.python.org/pypi/setuptools_scm.

```bash
$ foremast -v
3.17.2.dev10+gd62004be.d20170518
```