### PR TITLE
Tag support for lambda.

### DIFF
--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -43,6 +43,7 @@ class LambdaFunction(object):
         self.region = region
         self.properties = get_properties(prop_path)
         generated = get_details(app=self.app_name)
+        self.group = generated.data['project']
 
         try:
             self.pipeline = self.properties['pipeline']['lambda']
@@ -180,7 +181,12 @@ class LambdaFunction(object):
                 Description=self.description,
                 Timeout=int(self.timeout),
                 MemorySize=int(self.memory),
-                VpcConfig=vpc_config)
+                VpcConfig=vpc_config,
+                Tags={
+                    'app_group': self.group,
+                    'app_name': self.app_name
+                }
+            )
         except boto3.exceptions.botocore.exceptions.ClientError as error:
             if 'CreateNetworkInterface' in error.response['Error']['Message']:
                 message = '{0} is missing "ec2:CreateNetworkInterface"'.format(self.role_arn)


### PR DESCRIPTION
AWS recently added tagging support for lambda. This adds tags for lambda deployments.