### PR TITLE
IAM RDS Connect

### DIFF
--- a/_docs/configuration_files/pipeline_json/services.rest
+++ b/_docs/configuration_files/pipeline_json/services.rest
@@ -61,6 +61,16 @@ Add Lambda access.
    | *Type*: bool
    | *Default*: ``false``
 
+``rds-db``
+************
+
+Add RDS-DB Connect access to RDS DB Name/RDS DB User key pairs listed.
+(http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
+
+   | *Type*: dict
+   | *Default*: ``{}``
+   | *Example*: ``{"dbi_resource_id": "db_user", "*": "example_user"}```
+
 ``s3``
 ******
 

--- a/_docs/infra_assumptions.rst
+++ b/_docs/infra_assumptions.rst
@@ -120,13 +120,23 @@ The default generated pipeline requires a couple of Jenkins jobs to be setup in 
 
     - ``REGION``
 
-  - Example Shell after cloning Foremast::
+  - Example Shell after cloning Foremast
 
-     virtualenv -p python3 venv
-     . venv/bin/activate
-     pip install -U --quiet .
-
-     create-scaling-policy
+    .. code-block:: bash
+    
+       virtualenv -p python3 venv
+       . venv/bin/activate
+       pip install -U --quiet .
+       
+       create-scaling-policy
+       
+       # You can export these variables or also pass them beforehand such as:
+       export GIT_REPO=<repo_name>
+       export ENV=<spinnaker_env_name>
+       
+       PROJECT=<repo_project> RUNWAY_DIR=<OS_path_to_runway_dir> \
+          REGION=<spinnaker_env_region> \
+          foremast-infrastructure
 
 Gitlab
 ------

--- a/src/foremast/templates/infrastructure/iam/elasticache.json.j2
+++ b/src/foremast/templates/infrastructure/iam/elasticache.json.j2
@@ -6,7 +6,7 @@
             ],
             "Resource": [
             {%- for cluster_name in items %}
-                "arn:aws:elasticace:{{ region }}:{{ account_number }}:cluster/{{ cluster_name }}"
+                "arn:aws:elasticache:{{ region }}:{{ account_number }}:cluster/{{ cluster_name }}"
                 {%- if not loop.last -%}
                 ,
                 {%- endif -%}

--- a/src/foremast/templates/infrastructure/iam/rds-db.j2
+++ b/src/foremast/templates/infrastructure/iam/rds-db.j2
@@ -5,8 +5,8 @@
                 "rds-db:connect"
             ],
             "Resource": [
-            {%- for db_name, db_user in items.iteritems() %}
-                "arn:aws:rds-db:{{ region }}:{{ account_number }}:dbuser:{{ db_name }}/{{ db_user }}"
+            {%- for db_resource_id, db_user in items.iteritems() %}
+                "arn:aws:rds-db:{{ region }}:{{ account_number }}:dbuser:{{ db_resource_id }}/{{ db_user }}"
                 {{ "," if not loop.last }}
             {% endfor %} 
             ]

--- a/src/foremast/templates/infrastructure/iam/rds-db.j2
+++ b/src/foremast/templates/infrastructure/iam/rds-db.j2
@@ -1,0 +1,13 @@
+        {
+            "Sid": "RDSDBConnectAccess",
+            "Effect": "Allow",
+            "Action": [
+                "rds-db:connect"
+            ],
+            "Resource": [
+            {%- for db_name, db_user in items.iteritems() %}
+                "arn:aws:rds-db:{{ region }}:{{ account_number }}:dbuser:{{ db_name }}/{{ db_user }}"
+                {{ "," if not loop.last }}
+            {% endfor %} 
+            ]
+        }

--- a/src/foremast/templates/infrastructure/iam/rds-db.json.j2
+++ b/src/foremast/templates/infrastructure/iam/rds-db.json.j2
@@ -5,7 +5,7 @@
                 "rds-db:connect"
             ],
             "Resource": [
-            {%- for db_resource_id, db_user in items.iteritems() %}
+            {%- for db_resource_id, db_user in items.items() %}
                 "arn:aws:rds-db:{{ region }}:{{ account_number }}:dbuser:{{ db_resource_id }}/{{ db_user }}"
                 {{ "," if not loop.last }}
             {% endfor %} 


### PR DESCRIPTION
This enables developers to leverage the IAM as auth for RDS in AWS. They need to specify the DB name and DB user such as:
```
"rds-db": {"db_name_here": "username", "another_db_name": "db_user"}
```

Working on docs.

Also unrelated, fixed a typo in elasticache.