### PR TITLE
exposing runway_dir to the construct pipeline method

### DIFF
--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -76,7 +76,8 @@ def construct_pipeline_block(env='',
                              region='us-east-1',
                              region_subnets=None,
                              settings=None,
-                             pipeline_data=None):
+                             pipeline_data=None,
+                             runway_dir=''):
     """Create the Pipeline JSON from template.
 
     This handles the common repeatable patterns in a pipeline, such as
@@ -142,7 +143,7 @@ def construct_pipeline_block(env='',
     hc_grace_period = data['asg'].get('hc_grace_period')
     app_grace_period = data['asg'].get('app_grace_period')
     grace_period = hc_grace_period + app_grace_period
-    
+
     # TODO: Migrate the naming logic to an external library to make it easier
     #       to update in the future. Gogo-Utils looks like a good candidate
     ssh_keypair = data['asg'].get('ssh_keypair', None)
@@ -165,6 +166,7 @@ def construct_pipeline_block(env='',
         'promote_restrict': pipeline_data['promote_restrict'],
         'owner_email': pipeline_data['owner_email'],
         'scalingpolicy': scalingpolicy,
+        'runway_dir': runway_dir
     })
 
     if settings['app']['canary']:

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -236,7 +236,8 @@ class SpinnakerPipeline:
                     region=region,
                     region_subnets=region_subnets,
                     settings=self.settings[env],
-                    pipeline_data=self.settings['pipeline'])
+                    pipeline_data=self.settings['pipeline'],
+                    runway_dir=self.runway_dir)
 
                 pipelines[region]['stages'].extend(json.loads(block))
 


### PR DESCRIPTION
Problem:
Currently there is no way to namespace pipelines except to create new runways. Within the construction of the pipelines this namespace is not passed.

Solution:
Pass from the create_pipeline method the runway_dir to the construct_pipeline.