### PR TITLE
fix: Check Task should use a specific exception

### DIFF
--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -87,6 +87,28 @@ class SpinnakerTaskError(SpinnakerError):
         super().__init__(*errors)
 
 
+class SpinnakerTaskInconclusiveError(SpinnakerTaskError):
+    """Spinnaker Task state failed to reach terminal state in allowed time."""
+
+    def __init__(self, message):
+        mock_failure_stage = {
+            'context': {
+                'exception': {
+                    'details': {
+                        'errors': [message],
+                    },
+                },
+            },
+        }
+        spinnaker_task_state = {
+            'execution': {
+                'stages': [mock_failure_stage],
+            },
+        }
+
+        super().__init__(spinnaker_task_state)
+
+
 class SpinnakerPipelineCreationFailed(SpinnakerError):
     """Could not create Spinnaker Pipeline."""
     pass

--- a/src/foremast/utils/tasks.py
+++ b/src/foremast/utils/tasks.py
@@ -125,7 +125,7 @@ def check_task(taskid, timeout=DEFAULT_TASK_TIMEOUT, wait=2):
             wait=wait,
             exceptions=(AssertionError, ValueError), )
     except ValueError:
-        raise SpinnakerTaskInconclusiveError('Task failed to complete in time: {0}'.format(taskid))
+        raise SpinnakerTaskInconclusiveError('Task failed to complete in {0} seconds: {1}'.format(timeout, taskid))
 
 
 def wait_for_task(task_data):

--- a/src/foremast/utils/tasks.py
+++ b/src/foremast/utils/tasks.py
@@ -100,17 +100,17 @@ def _check_task(taskid):
         raise ValueError
 
 
-def check_task(taskid, timeout=DEFAULT_TASK_TIMEOUT):
+def check_task(taskid, timeout=DEFAULT_TASK_TIMEOUT, wait=2):
     """wrapper for check_task
 
     Args:
         taskid (str): the task id returned from post_task 
         timeout (int) (optional): how long to wait before failing the task
+        wait (int, optional): Seconds to pause between polling attempts.
 
     Returns:
         polls for task status.
     """
-    wait = 2
     max_attempts = int(timeout / wait)
     return retry_call(partial(_check_task, taskid),
                       max_attempts=max_attempts,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -346,17 +346,6 @@ def test_utils_subnets_get_subnets_api_error(mock_requests_get):
         result = get_subnets()
 
 
-@mock.patch('foremast.utils.tasks._check_task')
-@mock.patch('foremast.utils.tasks.requests.get')
-def test_utils_retry_task(mock_requests_get, mock_check_task):
-    """Validate task retries are configurable"""
-    taskid = 'fake_task'
-    mock_check_task.side_effect=ValueError
-    with pytest.raises(SpinnakerTaskInconclusiveError):
-        check_task(taskid, 4)
-        assert mock_check_task.call_count == 2
-
-
 @mock.patch('foremast.utils.tasks.check_task')
 @mock.patch('foremast.utils.tasks.post_task')
 @mock.patch('foremast.utils.tasks.TASK_TIMEOUTS')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -352,7 +352,7 @@ def test_utils_retry_task(mock_requests_get, mock_check_task):
     """Validate task retries are configurable"""
     taskid = 'fake_task'
     mock_check_task.side_effect=ValueError
-    with pytest.raises(ValueError):
+    with pytest.raises(SpinnakerTaskInconclusiveError):
         check_task(taskid, 4)
         assert mock_check_task.call_count == 2
 

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -10,6 +10,17 @@ FAIL_MESSAGE = 'TERMINAL'
 SUCCESS_MESSAGE = 'SUCCEEDED'
 
 
+@mock.patch('foremast.utils.tasks._check_task')
+@mock.patch('foremast.utils.tasks.requests.get')
+def test_utils_retry_task(mock_requests_get, mock_check_task):
+    """Validate task retries are configurable"""
+    taskid = 'fake_task'
+    mock_check_task.side_effect = ValueError
+    with pytest.raises(SpinnakerTaskInconclusiveError):
+        check_task(taskid, 4)
+        assert mock_check_task.call_count == 2
+
+
 @mock.patch('foremast.utils.tasks.requests')
 def test_task_success(mock_requests):
     """Successful Task."""

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -18,7 +18,7 @@ def test_utils_retry_task(mock_requests_get, mock_check_task):
     mock_check_task.side_effect = ValueError
     with pytest.raises(SpinnakerTaskInconclusiveError):
         check_task(taskid, timeout=2, wait=1)
-        assert mock_check_task.call_count == 2
+    assert mock_check_task.call_count == 2
 
 
 @mock.patch('foremast.utils.tasks.requests')

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from foremast.exceptions import SpinnakerTaskError
-from foremast.utils.tasks import _check_task
+from foremast.utils.tasks import _check_task, check_task
 
 FAIL_MESSAGE = 'TERMINAL'
 SUCCESS_MESSAGE = 'SUCCEEDED'
@@ -41,3 +41,12 @@ def test_task_unknown(mock_requests):
 
     with pytest.raises(ValueError):
         _check_task(taskid='')
+
+
+@mock.patch('foremast.utils.tasks._check_task')
+def test_polling_inconclusive(mock_check):
+    """Spinnaker Task with non-terminal state should raise exception."""
+    mock_check.side_effect = ValueError
+
+    with pytest.raises(ValueError):
+        check_task(taskid='', timeout=2)

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -51,12 +51,3 @@ def test_task_unknown(mock_requests):
 
     with pytest.raises(ValueError):
         _check_task(taskid='')
-
-
-@mock.patch('foremast.utils.tasks._check_task')
-def test_polling_inconclusive(mock_check):
-    """Spinnaker Task with non-terminal state should raise exception."""
-    mock_check.side_effect = ValueError
-
-    with pytest.raises(SpinnakerTaskInconclusiveError):
-        check_task(taskid='', timeout=1, wait=1)

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -1,6 +1,9 @@
 """Verify :func:`foremsat.utils.tasks.check_task` functionality."""
 from unittest import mock
 
+import pytest
+
+from foremast.exceptions import SpinnakerTaskError
 from foremast.utils.tasks import _check_task
 
 FAIL_MESSAGE = 'TERMINAL'
@@ -15,3 +18,17 @@ def test_task_success(mock_requests):
     result = _check_task(taskid='')
 
     assert result == SUCCESS_MESSAGE
+
+
+@mock.patch('foremast.utils.tasks.requests')
+def test_task_failure(mock_requests):
+    """Failed Task."""
+    mock_requests.get.return_value.json.return_value = {
+        'status': FAIL_MESSAGE,
+        'execution': {
+            'stages': [],
+        },
+    }
+
+    with pytest.raises(SpinnakerTaskError):
+        _check_task(taskid='')

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -17,7 +17,7 @@ def test_utils_retry_task(mock_requests_get, mock_check_task):
     taskid = 'fake_task'
     mock_check_task.side_effect = ValueError
     with pytest.raises(SpinnakerTaskInconclusiveError):
-        check_task(taskid, 4)
+        check_task(taskid, timeout=2, wait=1)
         assert mock_check_task.call_count == 2
 
 

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -49,4 +49,4 @@ def test_polling_inconclusive(mock_check):
     mock_check.side_effect = ValueError
 
     with pytest.raises(ValueError):
-        check_task(taskid='', timeout=2)
+        check_task(taskid='', timeout=1, wait=1)

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from foremast.exceptions import SpinnakerTaskError
+from foremast.exceptions import SpinnakerTaskError, SpinnakerTaskInconclusiveError
 from foremast.utils.tasks import _check_task, check_task
 
 FAIL_MESSAGE = 'TERMINAL'
@@ -48,5 +48,5 @@ def test_polling_inconclusive(mock_check):
     """Spinnaker Task with non-terminal state should raise exception."""
     mock_check.side_effect = ValueError
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SpinnakerTaskInconclusiveError):
         check_task(taskid='', timeout=1, wait=1)

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -32,3 +32,12 @@ def test_task_failure(mock_requests):
 
     with pytest.raises(SpinnakerTaskError):
         _check_task(taskid='')
+
+
+@mock.patch('foremast.utils.tasks.requests')
+def test_task_unknown(mock_requests):
+    """Unknown Task status raises exception to keep polling."""
+    mock_requests.get.return_value.json.return_value = {'status': ''}
+
+    with pytest.raises(ValueError):
+        _check_task(taskid='')

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -11,8 +11,7 @@ SUCCESS_MESSAGE = 'SUCCEEDED'
 
 
 @mock.patch('foremast.utils.tasks._check_task')
-@mock.patch('foremast.utils.tasks.requests.get')
-def test_utils_retry_task(mock_requests_get, mock_check_task):
+def test_utils_retry_task(mock_check_task):
     """Validate task retries are configurable"""
     taskid = 'fake_task'
     mock_check_task.side_effect = ValueError

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -12,7 +12,7 @@ SUCCESS_MESSAGE = 'SUCCEEDED'
 
 @mock.patch('foremast.utils.tasks._check_task')
 def test_utils_retry_task(mock_check_task):
-    """Validate task retries are configurable"""
+    """Validate task retries are configurable."""
     taskid = 'fake_task'
     mock_check_task.side_effect = ValueError
     with pytest.raises(SpinnakerTaskInconclusiveError):

--- a/tests/utils/tasks/test_check_task.py
+++ b/tests/utils/tasks/test_check_task.py
@@ -1,0 +1,17 @@
+"""Verify :func:`foremsat.utils.tasks.check_task` functionality."""
+from unittest import mock
+
+from foremast.utils.tasks import _check_task
+
+FAIL_MESSAGE = 'TERMINAL'
+SUCCESS_MESSAGE = 'SUCCEEDED'
+
+
+@mock.patch('foremast.utils.tasks.requests')
+def test_task_success(mock_requests):
+    """Successful Task."""
+    mock_requests.get.return_value.json.return_value = {'status': SUCCESS_MESSAGE}
+
+    result = _check_task(taskid='')
+
+    assert result == SUCCESS_MESSAGE


### PR DESCRIPTION
`foremast.utils.tasks.check_task()` needs to provide a specific exception when a Spinnaker Task fails to complete in time.