### PR TITLE
fix: ensure no  in SID

### DIFF
--- a/src/foremast/awslambda/s3_event/s3_event.py
+++ b/src/foremast/awslambda/s3_event/s3_event.py
@@ -72,7 +72,7 @@ def create_s3_event(app_name, env, region, rules):
     config = get_template(template_file='infrastructure/lambda/s3_event.json.j2', **template_kwargs)
 
     principal = 's3.amazonaws.com'
-    statement_id = "{}_s3_{}".format(app_name, bucket)
+    statement_id = "{}_s3_{}".format(app_name, bucket).replace('.','')
     source_arn = "arn:aws:s3:::{}".format(bucket)
     add_lambda_permissions(function=lambda_alias_arn,
                            env=env,


### PR DESCRIPTION
When a lambda function specifies s3 trigger on a bucket containing `.` character -

```
2017-06-23 20:07:38,220 [DEBUG] foremast.utils.awslambda:add_lambda_permissions:125 - Add permission error: An error occurred (ValidationException) when calling the AddPermission operation: 1 validation error detected: Value 'foremast-deploypss_s3_common.packages.pss.stage.gogoair.com' at 'statementId' failed to satisfy constraint: Member must satisfy regular expression pattern: ([a-zA-Z0-9-_]+)
```

Scrub the SID string of all `.`