### PR TITLE
feat: on function update also update tags

### DIFF
--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -195,7 +195,7 @@ class LambdaFunction(object):
 
         lambda_arn = get_lambda_arn(self.app_name, self.env, self.region)
         self.lambda_client.tag_resource(
-            Resource = lambda_arn,
+            Resource=lambda_arn,
             Tags={
                 'app_group': self.group,
                 'app_name': self.app_name

--- a/src/foremast/awslambda/awslambda.py
+++ b/src/foremast/awslambda/awslambda.py
@@ -21,7 +21,8 @@ import boto3
 from tryagain import retries
 
 from ..exceptions import RequiredKeyNotFound
-from ..utils import get_details, get_properties, get_role_arn, get_security_group_id, get_subnets
+from ..utils import (get_details, get_lambda_arn, get_properties, get_role_arn,
+                     get_security_group_id, get_subnets)
 
 LOG = logging.getLogger(__name__)
 
@@ -190,6 +191,15 @@ class LambdaFunction(object):
                 raise SystemExit(message)
 
             raise
+        LOG.info('Updating Lambda function tags')
+
+        lambda_arn = get_lambda_arn(self.app_name, self.env, self.region)
+        self.lambda_client.tag_resource(
+            Resource = lambda_arn,
+            Tags={
+                'app_group': self.group,
+                'app_name': self.app_name
+            })
 
         LOG.info("Successfully updated Lambda configuration.")
 


### PR DESCRIPTION
Currently we only set tags on lambda `create_function`. This adds tag updates to `update_function_configuration`.

If tags exist it will overwrite them without complaint. This lets us skip a check for the existence of these tag keys.

This code wouldn't be needed for people only using lambda deployments after creation tagging was added but it will ensure they remain correct if they are manually changed or removed. 

The documentation for boto's `update_function_configuration` does not include a Tags dict like boto's `create_function` does. Although it's possible this is supported and not documented since Lambda tags are relatively new.

This PR is based off the documented capabilities of boto.