### PR TITLE
fix errors in onetime pipelines for ec2 deployments

### DIFF
--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -186,12 +186,12 @@ class SpinnakerPipeline:
         pipeline_id = None
         found = False
         for pipeline in pipelines:
-            right_app_and_region = (pipeline['application'] == self.app_name) and (region in pipeline['name']) 
+            correct_app_and_region = (pipeline['application'] == self.app_name) and (region in pipeline['name']) 
             if onetime:
                 onetime_str = "(onetime-{})".format(self.environments[0])
-                if right_app_and_region and onetime_str in pipeline['name']:
+                if correct_app_and_region and onetime_str in pipeline['name']:
                     found = True
-            elif right_app_and_region:
+            elif correct_app_and_region:
                 found = True
 
             if found:

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -172,19 +172,29 @@ class SpinnakerPipeline:
 
         return resp.json()
 
-    def compare_with_existing(self, region='us-east-1'):
+    def compare_with_existing(self, region='us-east-1', onetime=False):
         """Compare desired pipeline with existing pipelines.
 
         Args:
             region (str): Region of desired pipeline.
+            onetime (bool): Looks for different pipeline if Onetime
 
         Returns:
             str: pipeline_id if existing, empty string of not.
         """
         pipelines = self.get_existing_pipelines()
         pipeline_id = None
+        found = False
         for pipeline in pipelines:
-            if (pipeline['application'] == self.app_name) and (region in pipeline['name']):
+            right_app_and_region = (pipeline['application'] == self.app_name) and (region in pipeline['name']) 
+            if onetime:
+                onetime_str = "(onetime-{})".format(self.environments[0])
+                if right_app_and_region and onetime_str in pipeline['name']:
+                    found = True
+            elif right_app_and_region:
+                found = True
+
+            if found:
                 self.log.info('Existing pipeline found - %s', pipeline['name'])
                 pipeline_id = pipeline['id']
                 break

--- a/src/foremast/pipeline/create_pipeline_onetime.py
+++ b/src/foremast/pipeline/create_pipeline_onetime.py
@@ -67,6 +67,13 @@ class SpinnakerPipelineOnetime(SpinnakerPipeline):
                                           self.environments[0])
         pipeline_json['name'] = name
 
+        #Inject pipeline Id so that it does not override existing pipelines
+        pipeline_id = super().compare_with_existing(onetime=True)
+        if pipeline_id:
+            pipeline_json['id'] = pipeline_id
+        else:
+            del pipeline_json['id']
+
         # disable trigger as not to accidently kick off multiple deployments
         for trigger in pipeline_json['triggers']:
             trigger['enabled'] = False

--- a/src/foremast/pipeline/create_pipeline_onetime.py
+++ b/src/foremast/pipeline/create_pipeline_onetime.py
@@ -39,11 +39,14 @@ class SpinnakerPipelineOnetime(SpinnakerPipeline):
                  trigger_job='',
                  prop_path='',
                  base='',
-                 onetime=''):
+                 onetime='',
+                 runway_dir=''):
         super().__init__(app=app,
                          trigger_job=trigger_job,
                          prop_path=prop_path,
-                         base=base)
+                         base=base,
+                         runway_dir=runway_dir,
+                         )
         self.environments = [onetime]
 
     def post_pipeline(self, pipeline):


### PR DESCRIPTION
This fixes onetime pipelines for ec2 deployments. Merging in #180 should get close to enabling this for other pipeline types. 

I had to add logic for handling Pipeline ID as this changed in spinnaker since we last used the onetime functionality.