### PR TITLE
Refactor Construct Pipeline Block to Segregate ec2 logic

### DIFF
--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -98,11 +98,11 @@ def get_template_name(env, pipeline_type):
 
 def construct_pipeline_block(env='',
                              generated=None,
-                             previous_env=None,
+                             previous_env='',
                              region='us-east-1',
                              settings=None,
                              pipeline_data=None,
-                             **kwargs):
+                             region_subnets=None):
     """Create the Pipeline JSON from template.
 
     This handles the common repeatable patterns in a pipeline, such as
@@ -141,7 +141,7 @@ def construct_pipeline_block(env='',
             env=env,
             region=region,
             project=generated.project,
-            region_subnets=kwargs.get('region_subnets'))
+            region_subnets=region_subnets)
     else:
         data = copy.deepcopy(settings)
 
@@ -163,7 +163,7 @@ def construct_pipeline_block(env='',
     return pipeline_json
 
 
-def ec2_pipeline_setup(appname=None, project=None, settings=None, env=None, region=None, region_subnets=None):
+def ec2_pipeline_setup(appname='', project='', settings=None, env='', region='', region_subnets=None):
     """Handles ec2 pipeline data setup
 
     Args:
@@ -184,7 +184,7 @@ def ec2_pipeline_setup(appname=None, project=None, settings=None, env=None, regi
 
     # Use different variable to keep template simple
     instance_security_groups = DEFAULT_EC2_SECURITYGROUPS[env]
-    instance_security_groups.append(gen_app_name)
+    instance_security_groups.append(appname)
     instance_security_groups.extend(settings['security_group']['instance_extras'])
 
     LOG.info('Instance security groups to attach: {0}'.format(instance_security_groups))

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -154,6 +154,7 @@ def construct_pipeline_block(env='',
         'previous_env': previous_env,
         'promote_restrict': pipeline_data['promote_restrict'],
         'owner_email': pipeline_data['owner_email'],
+        'pipeline': pipeline_data,
     })
 
     LOG.debug('Block data:\n%s', pformat(data))

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -69,6 +69,7 @@ def check_provider_healthcheck(settings, default_provider='Discovery'):
 
     return ProviderHealthCheck(providers=health_check_providers, has_healthcheck=has_healthcheck)
 
+
 def get_template_name(env, pipeline_type):
     """Generates the correct template name based on pipeline type
 
@@ -92,6 +93,7 @@ def get_template_name(env, pipeline_type):
 
     return template_name
 
+
 def construct_pipeline_block(env='',
                              generated=None,
                              previous_env=None,
@@ -100,7 +102,6 @@ def construct_pipeline_block(env='',
                              pipeline_data=None,
                              pipeline_type='ec2',
                              **kwargs):
-
     """Create the Pipeline JSON from template.
 
     This handles the common repeatable patterns in a pipeline, such as
@@ -155,10 +156,11 @@ def construct_pipeline_block(env='',
     })
 
     LOG.debug('Block data:\n%s', pformat(data))
-    
+
     template_name = get_template_name(env, pipeline_type)
     pipeline_json = get_template(template_file=template_name, data=data)
     return pipeline_json
+
 
 def ec2_pipeline_setup(**kwargs):
     """Handles ec2 pipeline data setup
@@ -244,4 +246,3 @@ def ec2_pipeline_setup(**kwargs):
     })
 
     return data
-

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -80,16 +80,17 @@ def get_template_name(env, pipeline_type):
     Returns:
         str: Name of template
     """
-    if pipeline_type == 'ec2':
-        if env.startswith('prod'):
-            template_name = 'pipeline/pipeline_{}.json.j2'.format(env)
-        else:
-            template_name = 'pipeline/pipeline_stages.json.j2'
+    if pipeline_type == 'ec2' and env.startswith('prod'):
+        template_name_format = '{pipeline_base}_{env}.json.j2'
+    elif pipeline_type == 'ec2':
+        template_name_format = '{pipeline_base}_stages.json.j2'
+    elif pipeline_type != 'ec2' and env.startswith('prod'):
+        template_name_format = '{pipeline_base}_{env}_{pipeline_type}.json.j2'
     else:
-        if env.startswith('prod'):
-            template_name = 'pipeline/pipeline_{}_{}.json.j2'.format(env, pipeline_type)
-        else:
-            template_name = 'pipeline/pipeline_stages_{}.json.j2'.format(pipeline_type)
+        template_name_format = '{pipeline_base}_stages_{pipeline_type}.json.j2'
+
+    pipeline_base = 'pipeline/pipeline'
+    template_name = template_name_format.format(pipeline_base=pipeline_base, env=env, pipeline_type=pipeline_type)
 
     return template_name
 

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -13,7 +13,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 """Create Pipelines for Spinnaker."""
 import collections
 import json
@@ -42,13 +41,7 @@ class SpinnakerPipeline:
         runway_dir (str): Path to local runway directory.
     """
 
-    def __init__(self,
-                 app='',
-                 trigger_job='',
-                 prop_path='',
-                 base='',
-                 runway_dir='',
-                 pipeline_type='ec2'):
+    def __init__(self, app='', trigger_job='', prop_path='', base='', runway_dir='', pipeline_type='ec2'):
         self.log = logging.getLogger(__name__)
 
         self.header = {'content-type': 'application/json'}
@@ -83,23 +76,17 @@ class SpinnakerPipeline:
 
         self.log.debug('Pipeline JSON:\n%s', pipeline_json)
 
-        pipeline_response = requests.post(url,
-                                          data=pipeline_json,
-                                          headers=self.header,
-                                          verify=GATE_CA_BUNDLE,
-                                          cert=GATE_CLIENT_CERT)
+        pipeline_response = requests.post(
+            url, data=pipeline_json, headers=self.header, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
 
-        self.log.debug('Pipeline creation response:\n%s',
-                       pipeline_response.text)
+        self.log.debug('Pipeline creation response:\n%s', pipeline_response.text)
 
         if not pipeline_response.ok:
             raise SpinnakerPipelineCreationFailed(
-                'Failed to create pipeline for {0}: {1}'.format(
-                    self.app_name, pipeline_response.json()))
+                'Failed to create pipeline for {0}: {1}'.format(self.app_name, pipeline_response.json()))
 
-
-        self.log.info('Successfully created "%s" pipeline in application "%s".',
-                      pipeline_dict['name'], pipeline_dict['application'])
+        self.log.info('Successfully created "%s" pipeline in application "%s".', pipeline_dict['name'],
+                      pipeline_dict['application'])
 
     def render_wrapper(self, region='us-east-1'):
         """Generate the base Pipeline wrapper.
@@ -128,8 +115,7 @@ class SpinnakerPipeline:
                 'Setting "root_volume_size" over 50G is not allowed. We found {0}G in your configs.'.format(
                     root_volume_size))
 
-        ami_id = ami_lookup(name=base,
-                            region=region)
+        ami_id = ami_lookup(name=base, region=region)
 
         ami_template_file = generate_packer_filename(provider, region, baking_process)
 
@@ -153,9 +139,7 @@ class SpinnakerPipeline:
 
         self.log.debug('Wrapper app data:\n%s', pformat(data))
 
-        wrapper = get_template(
-            template_file='pipeline/pipeline_wrapper.json.j2',
-            data=data)
+        wrapper = get_template(template_file='pipeline/pipeline_wrapper.json.j2', data=data)
 
         return json.loads(wrapper)
 
@@ -166,11 +150,8 @@ class SpinnakerPipeline:
             str: Pipeline config json
         """
         url = "{0}/applications/{1}/pipelineConfigs".format(API_URL, self.app_name)
-        resp = requests.get(url,
-                            verify=GATE_CA_BUNDLE,
-                            cert=GATE_CLIENT_CERT)
-        assert resp.ok, 'Failed to lookup pipelines for {0}: {1}'.format(
-            self.app_name, resp.text)
+        resp = requests.get(url, verify=GATE_CA_BUNDLE, cert=GATE_CLIENT_CERT)
+        assert resp.ok, 'Failed to lookup pipelines for {0}: {1}'.format(self.app_name, resp.text)
 
         return resp.json()
 
@@ -222,8 +203,7 @@ class SpinnakerPipeline:
         for env in pipeline_envs:
             for region in self.settings[env]['regions']:
                 regions_envs[region].append(env)
-        self.log.info('Environments and Regions for Pipelines:\n%s',
-                      json.dumps(regions_envs, indent=4))
+        self.log.info('Environments and Regions for Pipelines:\n%s', json.dumps(regions_envs, indent=4))
 
         subnets = None
         pipelines = {}

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -41,7 +41,7 @@ class SpinnakerPipeline:
         runway_dir (str): Path to local runway directory.
     """
 
-    def __init__(self, app='', trigger_job='', prop_path='', base='', runway_dir='', pipeline_type='ec2'):
+    def __init__(self, app='', trigger_job='', prop_path='', base='', runway_dir=''):
         self.log = logging.getLogger(__name__)
 
         self.header = {'content-type': 'application/json'}
@@ -57,7 +57,6 @@ class SpinnakerPipeline:
 
         self.settings = get_properties(prop_path)
         self.environments = self.settings['pipeline']['env']
-        self.pipeline_type = pipeline_type
 
     def post_pipeline(self, pipeline):
         """Send Pipeline JSON to Spinnaker.
@@ -215,7 +214,6 @@ class SpinnakerPipeline:
             previous_env = None
             for env in envs:
                 pipeline_block_data = {
-                    "pipeline_type": self.pipeline_type,
                     "env": env,
                     "generated": self.generated,
                     "previous_env": previous_env,
@@ -224,7 +222,7 @@ class SpinnakerPipeline:
                     "pipeline_data": self.settings['pipeline'],
                 }
 
-                if self.pipeline_type == 'ec2':
+                if self.settings['pipeline']['type'] == 'ec2':
                     if not subnets:
                         subnets = get_subnets()
                     try:

--- a/tests/pipeline/test_create_pipeline.py
+++ b/tests/pipeline/test_create_pipeline.py
@@ -1,0 +1,83 @@
+#   Foremast - Pipeline Tooling
+#
+#   Copyright 2016 Gogo, LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Test create_pipeline functionality"""
+
+import pytest
+from unittest import mock
+
+from foremast.pipeline import SpinnakerPipeline
+
+
+TEST_SETTINGS = { 
+        'dev': {
+                'app': 
+                    {'app_description': 'Test App Demo application'},
+                'deploy_strategy': 'highlander',
+                'regions': ['us-east-1'],
+        },
+        'pipeline': {
+                'base': 'tomcat8',
+                'config_commit': '',
+                'deployment': 'spinnaker',
+                'documentation': '',
+                'env': ['dev'],
+                'eureka': True,
+                'image': {'builder': 'ebs', 'root_volume_size': 6},
+                'regions': ['us-east-1', 'us-west-2'],
+                'type': 'ec2'
+        }
+}
+
+@mock.patch('foremast.pipeline.create_pipeline.get_properties')
+@mock.patch('foremast.pipeline.create_pipeline.get_details')
+@mock.patch('foremast.pipeline.create_pipeline.os')
+@pytest.fixture
+def spinnaker_pipeline(mock_os, mock_get_details, mock_get_prop):
+    """Sets up pipeline fixture object"""
+    mock_get_prop.return_value = TEST_SETTINGS
+    pipelineObj = SpinnakerPipeline(app='appgroup', trigger_job='a_group_app', )
+    pipelineObj.generated = 'test'
+    pipelineObj.app_name = 'appgroup'
+    pipelineObj.group_name = 'group'
+    return pipelineObj
+
+@mock.patch('foremast.pipeline.create_pipeline.clean_pipelines')
+@mock.patch.object(SpinnakerPipeline, 'render_wrapper')
+@mock.patch('foremast.pipeline.create_pipeline.get_subnets')
+@mock.patch('foremast.pipeline.create_pipeline.construct_pipeline_block')
+@mock.patch('foremast.pipeline.create_pipeline.renumerate_stages')
+@mock.patch.object(SpinnakerPipeline, 'post_pipeline')
+def test_create_pipeline_ec2(mock_post, mock_renumerate, mock_construct, mock_subnets, mock_wrapper, mock_clean, spinnaker_pipeline):
+    """test pipeline creation if ec2 pipeline."""
+    test_block_data = {
+                    "env": "dev",
+                    "generated": "test",
+                    "previous_env": None,
+                    "region": "us-east-1",
+                    "settings": spinnaker_pipeline.settings["dev"],
+                    "pipeline_data": spinnaker_pipeline.settings['pipeline'],
+                    "region_subnets": {'us-east-1': ['us-east-1d', 'us-east-1a', 'us-east-1e']}
+                }
+    mock_subnets.return_value = {'dev': {'us-east-1': ['us-east-1d', 'us-east-1a', 'us-east-1e']}}
+    mock_construct.return_value = '{"test": "stuff"}'
+    mock_wrapper.return_value = {'stages':[]}
+    created = spinnaker_pipeline.create_pipeline()
+
+    mock_construct.assert_called_with(**test_block_data)
+    mock_post.assert_called_with({'stages': ['test']})
+
+    assert created == True


### PR DESCRIPTION
This is an attempt to break #180 into smaller PRs

This just separates out ec2 logic from create_pipeline and construct_pipeline_block. This makes it easier to then refactor so that the separate classes for s3 and lambda can be removed. Makes the calls more generic 

