### PR TITLE
fix: Fail for bad GitLab Project ID lookup

### DIFF
--- a/src/foremast/exceptions.py
+++ b/src/foremast/exceptions.py
@@ -30,6 +30,10 @@ class ForemastConfigurationFileError(ForemastError):
     """Foremast configuration file misconfigured."""
 
 
+class GitLabApiError(ForemastError):
+    """GitLab API did not return a good status."""
+
+
 class SpinnakerError(ForemastError):
     """Spinnaker related error."""
     pass

--- a/tests/utils/test_file_lookups.py
+++ b/tests/utils/test_file_lookups.py
@@ -18,6 +18,8 @@ import base64
 from unittest import mock
 
 import pytest
+
+from foremast.exceptions import GitLabApiError
 from foremast.utils import FileLookup
 
 TEST_JSON = '''{
@@ -34,6 +36,27 @@ def test_init(gitlab):
     assert my_git.git_short == ''
     assert my_git.server == gitlab.Gitlab.return_value
     my_git.server.getproject.assert_called_with(my_git.git_short)
+
+
+@mock.patch('foremast.utils.lookups.gitlab')
+def test_project_id_exception(mock_gitlab):
+    """Check resolving GitLab Project ID fails with exception."""
+    mock_gitlab.Gitlab.return_value.getproject.return_value = False
+
+    with pytest.raises(GitLabApiError):
+        FileLookup()
+
+
+@mock.patch('foremast.utils.lookups.gitlab')
+def test_project_id_success(mock_gitlab):
+    """Check resolving GitLab Project ID is successful."""
+    project_id = 30
+
+    mock_gitlab.Gitlab.return_value.getproject.return_value = {'id': project_id}
+
+    seeker = FileLookup()
+
+    assert seeker.project_id == project_id
 
 
 @mock.patch('foremast.utils.lookups.gitlab')


### PR DESCRIPTION
We observed the stack trace:
```
Traceback (most recent call last):
  File "/tmp/workspace/pipes-pipeline-prepare/venv/bin/prepare-infrastructure", line 11, in <module>
    sys.exit(prepare_infrastructure())
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.5/site-packages/foremast/runner.py", line 256, in prepare_infrastructure
    runner.write_configs()
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.5/site-packages/foremast/runner.py", line 75, in write_configs
    app_configs = configs.process_git_configs(git_short=self.git_short)
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.5/site-packages/foremast/configs/prepare_configs.py", line 39, in process_git_configs
    file_lookup = FileLookup(git_short=git_short)
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.5/site-packages/foremast/utils/lookups.py", line 88, in __init__
    self.project_id = self.server.getproject(self.git_short)['id']
TypeError: 'bool' object is not subscriptable
```
This occurs when trying to resolve a GitLab Project ID and the underlying package `pyapi-gitlab` returns a `False`. There is ongoing work upstream in https://github.com/pyapi-gitlab/pyapi-gitlab/issues/193 to raise an exception, but this is needed for now to make the failure more obvious.