### PR TITLE
Added ability to have default application securitygroup rules

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -122,6 +122,11 @@ the groups are applied to all environments. If a json is provide, it assigns gro
     | *Example (json)*: ``{"dev": ["sg1", "sg2"], "stage": ["sg3"]}``
 
 
+''default_securitygroup_rules''
+*******************************
+    | *Required*: No
+    | *Example*: ``{ "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ] }``
+
 ``gate_client_cert``
 ********************
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -30,10 +30,9 @@ import ast
 import json
 import logging
 import sys
-
 from configparser import ConfigParser, DuplicateSectionError
-from os.path import expanduser, expandvars, exists
 from os import getcwd, path
+from os.path import exists, expanduser, expandvars
 
 LOG = logging.getLogger(__name__)
 LOGGING_FORMAT = '%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s'
@@ -200,8 +199,16 @@ REGIONS = set(validate_key_values(config, 'base', 'regions', default='').split('
 ALLOWED_TYPES = set(validate_key_values(config, 'base', 'types', default='ec2,lambda,s3,datapipeline').split(','))
 TEMPLATES_PATH = validate_key_values(config, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
+<<<<<<< HEAD
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
+=======
+DEFAULT_EC2_SECURITYGROUPS = set(validate_key_values(config, 'base', 'default_ec2_securitygroups',
+                                 default='').split(','))
+DEFAULT_ELB_SECURITYGROUPS = set(validate_key_values(config, 'base', 'default_elb_securitygroups',
+                                 default='').split(','))
+DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'default_securitygroup_rules', 'rules', default="[]"))
+>>>>>>> Added ability to have default application securitygroup rules
 GITLAB_TOKEN = validate_key_values(config, 'credentials', 'gitlab_token')
 SLACK_TOKEN = validate_key_values(config, 'credentials', 'slack_token')
 DEFAULT_TASK_TIMEOUT = validate_key_values(config, 'task_timeouts', 'default', default=120)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -202,8 +202,6 @@ AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
 DEFAULT_SECURITYGROUP_RULES = _generate_security_groups('default_securitygroup_rules')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
-DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'base', 'default_securitygroup_rules',
-                                  default="{}"))
 GITLAB_TOKEN = validate_key_values(config, 'credentials', 'gitlab_token')
 SLACK_TOKEN = validate_key_values(config, 'credentials', 'slack_token')
 DEFAULT_TASK_TIMEOUT = validate_key_values(config, 'task_timeouts', 'default', default=120)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -199,6 +199,7 @@ REGIONS = set(validate_key_values(config, 'base', 'regions', default='').split('
 ALLOWED_TYPES = set(validate_key_values(config, 'base', 'types', default='ec2,lambda,s3,datapipeline').split(','))
 TEMPLATES_PATH = validate_key_values(config, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
+DEFAULT_SECURITYGROUP_RULES = _generate_security_groups('default_securitygroup_rules')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
 DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'base', 'default_securitygroup_rules',

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -202,7 +202,7 @@ AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
 DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'base', 'default_securitygroup_rules',
-                                 default="{}"))
+                                  default="{}"))
 GITLAB_TOKEN = validate_key_values(config, 'credentials', 'gitlab_token')
 SLACK_TOKEN = validate_key_values(config, 'credentials', 'slack_token')
 DEFAULT_TASK_TIMEOUT = validate_key_values(config, 'task_timeouts', 'default', default=120)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -199,16 +199,10 @@ REGIONS = set(validate_key_values(config, 'base', 'regions', default='').split('
 ALLOWED_TYPES = set(validate_key_values(config, 'base', 'types', default='ec2,lambda,s3,datapipeline').split(','))
 TEMPLATES_PATH = validate_key_values(config, 'base', 'templates_path')
 AMI_JSON_URL = validate_key_values(config, 'base', 'ami_json_url')
-<<<<<<< HEAD
 DEFAULT_EC2_SECURITYGROUPS = _generate_security_groups('default_ec2_securitygroups')
 DEFAULT_ELB_SECURITYGROUPS = _generate_security_groups('default_elb_securitygroups')
-=======
-DEFAULT_EC2_SECURITYGROUPS = set(validate_key_values(config, 'base', 'default_ec2_securitygroups',
-                                 default='').split(','))
-DEFAULT_ELB_SECURITYGROUPS = set(validate_key_values(config, 'base', 'default_elb_securitygroups',
-                                 default='').split(','))
-DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'default_securitygroup_rules', 'rules', default="[]"))
->>>>>>> Added ability to have default application securitygroup rules
+DEFAULT_SECURITYGROUP_RULES = json.loads(validate_key_values(config, 'base', 'default_securitygroup_rules',
+                                 default="{}"))
 GITLAB_TOKEN = validate_key_values(config, 'credentials', 'gitlab_token')
 SLACK_TOKEN = validate_key_values(config, 'credentials', 'slack_token')
 DEFAULT_TASK_TIMEOUT = validate_key_values(config, 'task_timeouts', 'default', default=120)

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -206,6 +206,7 @@ class SpinnakerSecurityGroup(object):
         return True
 
     def update_default_securitygroup_rules(self):
+        """Concatinate application and global security group rules"""
         ingress = self.properties['security_group']['ingress']
         ingress.update(DEFAULT_SECURITYGROUP_RULES)
         return ingress

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -205,6 +205,11 @@ class SpinnakerSecurityGroup(object):
 
         return True
 
+    def update_default_securitygroup_rules(self):
+        ingress = self.properties['security_group']['ingress']
+        ingress.update(DEFAULT_SECURITYGROUP_RULES)
+        return ingress
+
     def create_security_group(self):
         """Send a POST to spinnaker to create a new security group.
 
@@ -218,8 +223,7 @@ class SpinnakerSecurityGroup(object):
         ingress_rules = []
 
         try:
-            ingress = self.properties['security_group']['ingress']
-            ingress.update(DEFAULT_SECURITYGROUP_RULES)
+            ingress = self.update_default_securitygroup_rules()
         except KeyError:
             msg = 'Possible missing configuration for "{0}".'.format(self.env)
             self.log.error(msg)

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -46,7 +46,9 @@ import logging
 import boto3
 from boto3.exceptions import botocore
 
-from ..exceptions import (ForemastConfigurationFileError, SpinnakerSecurityGroupCreationFailed,
+from ..consts import DEFAULT_SECURITYGROUP_RULES
+from ..exceptions import (ForemastConfigurationFileError,
+                          SpinnakerSecurityGroupCreationFailed,
                           SpinnakerSecurityGroupError)
 from ..utils import (get_properties, get_security_group_id, get_template,
                      get_vpc_id, wait_for_task, warn_user, get_details)
@@ -217,6 +219,7 @@ class SpinnakerSecurityGroup(object):
 
         try:
             ingress = self.properties['security_group']['ingress']
+            ingress.update(DEFAULT_SECURITYGROUP_RULES)
         except KeyError:
             msg = 'Possible missing configuration for "{0}".'.format(self.env)
             self.log.error(msg)

--- a/src/foremast/templates/configs/config.py.example
+++ b/src/foremast/templates/configs/config.py.example
@@ -9,6 +9,7 @@ CONFIG = {
         'git_url': 'https://git.example.com',
         'gate_api_url': 'http://gate-api.example.com:8084',
         'templates_path': '../../foremast-templates',
+        'default_securitygroup_rules': {'myapp1': '[{\'start_port\': \'22\', \'end_port\': \'22\', \'protocol\': \'tcp\'}]', 'myapp2': '[{\'start_port\': \'8080\', \'end_port\': \'8080\', \'protocol\': \'tcp\' }]'},
     },
     'credentials': {
         'gitlab_token': '123token23423343',

--- a/src/foremast/templates/configs/config.py.example
+++ b/src/foremast/templates/configs/config.py.example
@@ -9,7 +9,10 @@ CONFIG = {
         'git_url': 'https://git.example.com',
         'gate_api_url': 'http://gate-api.example.com:8084',
         'templates_path': '../../foremast-templates',
-        'default_securitygroup_rules': {'myapp1': '[{\'start_port\': \'22\', \'end_port\': \'22\', \'protocol\': \'tcp\'}]', 'myapp2': '[{\'start_port\': \'8080\', \'end_port\': \'8080\', \'protocol\': \'tcp\' }]'},
+        'default_securitygroup_rules': {
+            'bastion': [{'start_port': '22', 'end_port': '22', 'protocol': 'tcp'}],
+            'serviceapp': [{'start_port': '8080', 'end_port': '8080', 'protocol': 'tcp' }],
+        },
     },
     'credentials': {
         'gitlab_token': '123token23423343',

--- a/src/foremast/templates/configs/foremast.cfg.example
+++ b/src/foremast/templates/configs/foremast.cfg.example
@@ -8,7 +8,7 @@ git_url = https://git.example.com
 gate_api_url = http://gate-api.example.com:8084
 templates_path = ../../foremast-templates
 default_securitygroup_rules = { "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ],
-                                "eureka" : [ { "start_port": "8080", "end_port": "8080", "protocol": "tcp" } ] }
+                                "serviceapp" : [ { "start_port": "8080", "end_port": "8080", "protocol": "tcp" } ] }
 
 [credentials]
 gitlab_token = 123token23423343

--- a/src/foremast/templates/configs/foremast.cfg.example
+++ b/src/foremast/templates/configs/foremast.cfg.example
@@ -7,6 +7,8 @@ ami_json_url = http://s3.bucketname.com/ami_lookup.json
 git_url = https://git.example.com
 gate_api_url = http://gate-api.example.com:8084
 templates_path = ../../foremast-templates
+default_securitygroup_rules = { "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ],
+                                "eureka" : [ { "start_port": "8080", "end_port": "8080", "protocol": "tcp" } ] }
 
 [credentials]
 gitlab_token = 123token23423343

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -42,6 +42,12 @@ def test_consts_pipeline_types():
     assert 'lambda' in ALLOWED_TYPES
 
 
+def test_consts_default_securitygroup_rules():
+    """Test this const is a dict"""
+    assert isinstance(DEFAULT_SECURITYGROUP_RULES, dict)
+    # assert DEFAULT_SECURITYGROUP_RULES == {} or {'': []}
+
+
 @patch('foremast.consts.validate_key_values')
 def test_parse_security_group(values):
     """Parse out security group entries"""
@@ -56,9 +62,3 @@ def test_parse_security_group(values):
 def test_parse_security_group_dict(mock_keys):
     """Validate security groups are handled properly if dictionary is in dyanmic config"""
     assert {'': ['g3']} == _generate_security_groups('default_elb_securitygroups')
-
-
-def test_consts_default_securitygroup_rules():
-    """Test this const is a dict"""
-    assert isinstance(DEFAULT_SECURITYGROUP_RULES, dict)
-    assert DEFAULT_SECURITYGROUP_RULES == {}

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -17,7 +17,8 @@
 from configparser import ConfigParser
 from unittest.mock import patch
 
-from foremast.consts import ALLOWED_TYPES, extract_formats, _generate_security_groups
+from foremast.consts import (ALLOWED_TYPES, DEFAULT_SECURITYGROUP_RULES,
+                             extract_formats, _generate_security_groups)
 
 
 def test_consts_extract_formats():
@@ -55,3 +56,9 @@ def test_parse_security_group(values):
 def test_parse_security_group_dict(mock_keys):
     """Validate security groups are handled properly if dictionary is in dyanmic config"""
     assert {'': ['g3']} == _generate_security_groups('default_elb_securitygroups')
+
+
+def test_consts_default_securitygroup_rules():
+    """Test this const is a dict"""
+    assert isinstance(DEFAULT_SECURITYGROUP_RULES, dict)
+    assert DEFAULT_SECURITYGROUP_RULES == {}

--- a/tests/test_default_security_groups.py
+++ b/tests/test_default_security_groups.py
@@ -1,0 +1,30 @@
+"""Test default Security Groups."""
+from unittest import mock
+
+from foremast.securitygroup.create_securitygroup import SpinnakerSecurityGroup
+
+
+@mock.patch('foremast.securitygroup.create_securitygroup.get_properties')
+def test_default_security_groups(mock_properties):
+    """Make sure default Security Groups are added to the ingress rules."""
+    ingress = {
+        'test_app': [
+            {
+                'start_port': 30,
+                'end_port': 30,
+            },
+        ],
+    }
+
+    mock_properties.return_value = {
+        'security_group': {
+            'ingress': ingress,
+            'description': '',
+        },
+    }
+
+    test_sg = {'myapp': [{'start_port': '22', 'end_port': '22', 'protocol': 'tcp' }]}
+    with mock.patch.dict('foremast.securitygroup.create_securitygroup.DEFAULT_SECURITYGROUP_RULES', test_sg):
+        test_sg = SpinnakerSecurityGroup()
+        ingress = test_sg.update_default_securitygroup_rules()
+        assert 'myapp' in ingress

--- a/tests/test_default_security_groups.py
+++ b/tests/test_default_security_groups.py
@@ -4,8 +4,9 @@ from unittest import mock
 from foremast.securitygroup.create_securitygroup import SpinnakerSecurityGroup
 
 
+@mock.patch('foremast.securitygroup.create_securitygroup.get_details')
 @mock.patch('foremast.securitygroup.create_securitygroup.get_properties')
-def test_default_security_groups(mock_properties):
+def test_default_security_groups(mock_properties, mock_details):
     """Make sure default Security Groups are added to the ingress rules."""
     ingress = {
         'test_app': [
@@ -23,8 +24,12 @@ def test_default_security_groups(mock_properties):
         },
     }
 
-    test_sg = {'myapp': [{'start_port': '22', 'end_port': '22', 'protocol': 'tcp' }]}
+    test_sg = {
+        'myapp': [
+            {'start_port': '22', 'end_port': '22', 'protocol': 'tcp'},
+        ]
+    }
     with mock.patch.dict('foremast.securitygroup.create_securitygroup.DEFAULT_SECURITYGROUP_RULES', test_sg):
-        test_sg = SpinnakerSecurityGroup()
-        ingress = test_sg.update_default_securitygroup_rules()
+        sg = SpinnakerSecurityGroup()
+        ingress = sg.update_default_securitygroup_rules()
         assert 'myapp' in ingress


### PR DESCRIPTION
Works with an addition like -

```
[base]
default_securitygroup_rules = { "bastion" : [ { "start_port": "22", "end_port": "22", "protocol": "tcp" } ],
          "eureka" : [ { "start_port": "8080", "end_port": "8080", "protocol": "tcp" } ] }
``` 
to foremast.cfg