### PR TITLE
Add account level security group configuration options

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -102,18 +102,21 @@ Path to custome templates directory. If provided, Foremast will first look in th
 ``default_ec2_securitygroups``
 ******************************
 
-Comma seperated list of EC2 security groups to include for all deployments
+Comma separated list or json of EC2 security groups to include for all deployments. If a command separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``office,test_sg,example``
+    | *Example (json)*: ``{"dev": ["sg1", "sg2"], "stage": ["sg3"]}``
 
 ``default_elb_securitygroups``
 ******************************
 
-Comma seperated list of ELB security groups to include for all deployments
+Comma separated list or json of ELB security groups to include for all deployments. If a command separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``test_sg,example_elb_sg``
+    | *Example (json)*: ``{"dev": ["sg1", "sg2"], "stage": ["sg3"]}``
+
 
 ``gate_client_cert``
 ********************
@@ -224,7 +227,7 @@ An string of the format of the application's jenkins job name
 
 Section handling customization of task timeouts when communicating with Spinnaker.
 
-Timeouts can vary per environment and per task. 
+Timeouts can vary per environment and per task.
 
 ``default``
 ***********

--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -45,7 +45,7 @@ The base domain of your applications. Used for generating DNS
 ``envs``
 ********
 
-Comma delimiated list of environments/applications that will be managed with Foremast
+Comma delimited list of environments/applications that will be managed with Foremast
 
     | *Example*: ``dev,stage,prod``
     | *Required*: Yes
@@ -102,7 +102,7 @@ Path to custome templates directory. If provided, Foremast will first look in th
 ``default_ec2_securitygroups``
 ******************************
 
-Comma separated list or json of EC2 security groups to include for all deployments. If a command separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
+Comma separated list or json of EC2 security groups to include for all deployments. If a comma separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``office,test_sg,example``
@@ -111,7 +111,7 @@ Comma separated list or json of EC2 security groups to include for all deploymen
 ``default_elb_securitygroups``
 ******************************
 
-Comma separated list or json of ELB security groups to include for all deployments. If a command separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
+Comma separated list or json of ELB security groups to include for all deployments. If a comma separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``test_sg,example_elb_sg``

--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -95,14 +95,17 @@ FQDN Of your spinnaker Gate instance. This is where all API calls to Spinnaker w
 ``templates_path``
 ******************
 
-Path to custome templates directory. If provided, Foremast will first look in this directory for any templates. This can be an absolute path, or a path relative to where you where you are running the Foremast commands. See :ref:`pipeline_examples` for more details on custom templates.
+Path to custom templates directory. If provided, Foremast will first look in this directory for any templates. This can
+be an absolute path, or a path relative to where you where you are running the Foremast commands. See
+:ref:`pipeline_examples` for more details on custom templates.
 
     | *Required*: No
 
 ``default_ec2_securitygroups``
 ******************************
 
-Comma separated list or json of EC2 security groups to include for all deployments. If a comma separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
+Comma separated list or json of EC2 security groups to include for all deployments. If a comma separated list is given,
+the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``office,test_sg,example``
@@ -111,7 +114,8 @@ Comma separated list or json of EC2 security groups to include for all deploymen
 ``default_elb_securitygroups``
 ******************************
 
-Comma separated list or json of ELB security groups to include for all deployments. If a comma separated list is given, the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
+Comma separated list or json of ELB security groups to include for all deployments. If a comma separated list is given,
+the groups are applied to all environments. If a json is provide, it assigns groups only to the specified environment.
 
     | *Required*: No
     | *Example*: ``test_sg,example_elb_sg``
@@ -121,7 +125,8 @@ Comma separated list or json of ELB security groups to include for all deploymen
 ``gate_client_cert``
 ********************
 
-If accessing Gate via x509 certificate authentication, this value provides the local path to the certificate. Only PEM certs are supported at this time (containing both the key and certificate in the PEM).
+If accessing Gate via x509 certificate authentication, this value provides the local path to the certificate. Only PEM
+certs are supported at this time (containing both the key and certificate in the PEM).
 
     | *Required*: No
     | *Example*: ``/var/certs/gate-cert.pem``
@@ -129,7 +134,9 @@ If accessing Gate via x509 certificate authentication, this value provides the l
 ``gate_ca_bundle``
 ********************
 
-If accessing Gate via x509 leveraging a custom certificate authority (such as acting as your own CA), this value provides the local path to the CA bundle. It is recommended to use an existing CA Bundle and append your CA certificate to it (https://certifi.io/en/latest/)
+If accessing Gate via x509 leveraging a custom certificate authority (such as acting as your own CA), this value
+provides the local path to the CA bundle. It is recommended to use an existing CA Bundle and append your CA certificate
+to it (https://certifi.io/en/latest/)
 
     | *Required*: No
     | *Example*: ``/var/certs/CA.pem``
@@ -171,7 +178,8 @@ Comma delimiated list of applications to whitelist from ASG rules
 
 Section handling the naming convention of applications, elb, iam, s3 buckets and other services.
 
-The most common sections are shown. The complete list of sections and defaults are defined by the underlying library gogo-utils_.
+The most common sections are shown. The complete list of sections and defaults are defined by the underlying library
+gogo-utils_.
 
 Any of the possible variables below can be used as the value.
 

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -26,6 +26,7 @@ descending order. First found wins.
 .. literalinclude:: ../../src/foremast/templates/configs/foremast.cfg.example
    :language: ini
 """
+import ast
 import json
 import logging
 import sys
@@ -148,6 +149,18 @@ def _remove_empty_entries(entries):
     return entries
 
 
+def _convert_string_to_native(value):
+    """Convert a string to its native python type"""
+    result = None
+
+    try:
+        result = ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        # Likely a string
+        result = value.split(',')
+    return result
+
+
 def _generate_security_groups(config_key):
     """Read config file and generate security group dict by environemnt
 
@@ -157,7 +170,8 @@ def _generate_security_groups(config_key):
     Returns:
         dict: of environments in {$env: [$group1, group2]} format
     """
-    default_groups = validate_key_values(config, 'base', config_key, default='')
+    raw_default_groups = validate_key_values(config, 'base', config_key, default='')
+    default_groups = _convert_string_to_native(raw_default_groups)
     LOG.debug('Default security group for %s is %s', config_key, default_groups)
 
     if isinstance(default_groups, (str)):

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -140,6 +140,13 @@ def find_config():
 
     return configurations
 
+def _remove_empty_entries(entries):
+    """Remove emtpy entries in a list"""
+    for entry in entries:
+        if entry in ['', None]:
+            entries.pop()
+    return entries
+
 
 def _generate_security_groups(config_key):
     """Read config file and generate security group dict by environemnt
@@ -157,7 +164,8 @@ def _generate_security_groups(config_key):
         try:
             default_groups = json.loads(default_groups)
         except json.JSONDecodeError:
-            default_groups = default_groups.split(',')
+            groups = default_groups.split(',')
+            default_groups = _remove_empty_entries(groups)
 
     entries = {}
     if isinstance(default_groups, (list)):

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -174,20 +174,17 @@ def _generate_security_groups(config_key):
     default_groups = _convert_string_to_native(raw_default_groups)
     LOG.debug('Default security group for %s is %s', config_key, default_groups)
 
-    if isinstance(default_groups, (str)):
-        try:
-            default_groups = json.loads(default_groups)
-        except json.JSONDecodeError:
-            groups = default_groups.split(',')
-            default_groups = _remove_empty_entries(groups)
-
     entries = {}
+    for env in ENVS:
+        entries[env] = []
+
     if isinstance(default_groups, (list)):
-        # convert single entries to all accounts
-        for env in ENVS:
-            entries[env] = sorted(set(default_groups))
-    else:
-        entries = default_groups
+        groups = _remove_empty_entries(default_groups)
+        for env in entries:
+            entries[env] = sorted(set(groups))
+
+    if isinstance(default_groups, (dict)):
+        entries.update(default_groups)
 
     LOG.debug('Generated security group: %s', entries)
     return entries

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -184,8 +184,7 @@ def _generate_security_groups(config_key):
         groups = _remove_empty_entries(default_groups)
         for env in entries:
             entries[env] = groups
-
-    if isinstance(default_groups, (dict)):
+    elif isinstance(default_groups, (dict)):
         entries.update(default_groups)
 
     LOG.debug('Generated security group: %s', entries)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -164,7 +164,7 @@ def _convert_string_to_native(value):
 
 
 def _generate_security_groups(config_key):
-    """Read config file and generate security group dict by environment
+    """Read config file and generate security group dict by environment.
 
     Args:
         config_key (str): Configuration file key

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -142,7 +142,7 @@ def find_config():
     return configurations
 
 def _remove_empty_entries(entries):
-    """Remove emtpy entries in a list"""
+    """Remove empty entries in a list"""
     for count, entry in enumerate(entries):
         if entry in ['', None]:
             entries.pop(count)
@@ -162,13 +162,13 @@ def _convert_string_to_native(value):
 
 
 def _generate_security_groups(config_key):
-    """Read config file and generate security group dict by environemnt
+    """Read config file and generate security group dict by environment
 
     Args:
         config_key (str): Configuration file key
 
     Returns:
-        dict: of environments in {$env: [$group1, group2]} format
+        dict: of environments in {'env1': ['group1', 'group2']} format
     """
     raw_default_groups = validate_key_values(config, 'base', config_key, default='')
     default_groups = _convert_string_to_native(raw_default_groups)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -41,6 +41,7 @@ SHORT_LOGGING_FORMAT = '[%(levelname)s] %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT)
 logging.getLogger(__package__.split('.')[0]).setLevel(logging.INFO)
 
+
 def validate_key_values(config_handle, section, key, default=None):
     """Warn when *key* is missing from configuration *section*.
 
@@ -99,10 +100,10 @@ def load_dynamic_config(configurations, config_dir=getcwd()):
     try:
         config_module = __import__('config')
 
-        for k, v in config_module.CONFIG.items():
-            LOG.debug('Importing %s with key %s', k, v)
+        for key, value in config_module.CONFIG.items():
+            LOG.debug('Importing %s with key %s', key, value)
             # Update configparser object
-            configurations.update({k: v})
+            configurations.update({key: value})
     except ImportError:
         # Provide a default if config not found
         configurations = {}
@@ -139,6 +140,7 @@ def find_config():
 
     return configurations
 
+
 def _generate_security_groups(config_key):
     """Read config file and generate security group dict by environemnt
 
@@ -156,7 +158,6 @@ def _generate_security_groups(config_key):
             default_groups = json.loads(default_groups)
         except json.JSONDecodeError:
             default_groups = default_groups.split(',')
-
 
     entries = {}
     if isinstance(default_groups, (list)):

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -145,10 +145,10 @@ def find_config():
 def _remove_empty_entries(entries):
     """Remove empty entries in a list"""
     valid_entries = []
-    for entry in entries:
+    for entry in set(entries):
         if entry:
             valid_entries.append(entry)
-    return sorted(set(valid_entries))
+    return sorted(valid_entries)
 
 
 def _convert_string_to_native(value):

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -141,12 +141,14 @@ def find_config():
 
     return configurations
 
+
 def _remove_empty_entries(entries):
     """Remove empty entries in a list"""
-    for count, entry in enumerate(entries):
-        if entry in ['', None]:
-            entries.pop(count)
-    return entries
+    valid_entries = []
+    for entry in entries:
+        if entry:
+            valid_entries.append(entry)
+    return sorted(set(valid_entries))
 
 
 def _convert_string_to_native(value):
@@ -181,7 +183,7 @@ def _generate_security_groups(config_key):
     if isinstance(default_groups, (list)):
         groups = _remove_empty_entries(default_groups)
         for env in entries:
-            entries[env] = sorted(set(groups))
+            entries[env] = groups
 
     if isinstance(default_groups, (dict)):
         entries.update(default_groups)

--- a/src/foremast/consts.py
+++ b/src/foremast/consts.py
@@ -143,9 +143,9 @@ def find_config():
 
 def _remove_empty_entries(entries):
     """Remove emtpy entries in a list"""
-    for entry in entries:
+    for count, entry in enumerate(entries):
         if entry in ['', None]:
-            entries.pop()
+            entries.pop(count)
     return entries
 
 

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -78,7 +78,7 @@ class SpinnakerELB:
         access_log = elb_settings.get('access_log', {})
         connection_draining_timeout = elb_settings.get('connection_draining_timeout', None)
 
-        security_groups = list(DEFAULT_ELB_SECURITYGROUPS)
+        security_groups = DEFAULT_ELB_SECURITYGROUPS[env]
         security_groups.append(self.app)
         security_groups.extend(self.properties['security_group']['elb_extras'])
 

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -113,7 +113,7 @@ def construct_pipeline_block(env='',
     user_data = generate_encoded_user_data(env=env, region=region, app_name=gen_app_name, group_name=generated.project)
 
     # Use different variable to keep template simple
-    instance_security_groups = list(DEFAULT_EC2_SECURITYGROUPS)
+    instance_security_groups = DEFAULT_EC2_SECURITYGROUPS[env]
     instance_security_groups.append(gen_app_name)
     instance_security_groups.extend(settings['security_group']['instance_extras'])
 

--- a/src/foremast/pipeline/construct_pipeline_block.py
+++ b/src/foremast/pipeline/construct_pipeline_block.py
@@ -147,7 +147,7 @@ def construct_pipeline_block(env='',
     hc_grace_period = data['asg'].get('hc_grace_period')
     app_grace_period = data['asg'].get('app_grace_period')
     grace_period = hc_grace_period + app_grace_period
-    
+
     # TODO: Migrate the naming logic to an external library to make it easier
     #       to update in the future. Gogo-Utils looks like a good candidate
     ssh_keypair = data['asg'].get('ssh_keypair', None)

--- a/src/foremast/pipeline/construct_pipeline_block_lambda.py
+++ b/src/foremast/pipeline/construct_pipeline_block_lambda.py
@@ -67,7 +67,7 @@ def construct_pipeline_block_lambda(env='',
                                            group_name=generated.project)
 
     # Use different variable to keep template simple
-    instance_security_groups = list(DEFAULT_EC2_SECURITYGROUPS)
+    instance_security_groups = DEFAULT_EC2_SECURITYGROUPS[env]
     instance_security_groups.append(gen_app_name)
     instance_security_groups.extend(settings['security_group']['instance_extras'])
 

--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -186,7 +186,7 @@ class SpinnakerPipeline:
         pipeline_id = None
         found = False
         for pipeline in pipelines:
-            correct_app_and_region = (pipeline['application'] == self.app_name) and (region in pipeline['name']) 
+            correct_app_and_region = (pipeline['application'] == self.app_name) and (region in pipeline['name'])
             if onetime:
                 onetime_str = "(onetime-{})".format(self.environments[0])
                 if correct_app_and_region and onetime_str in pipeline['name']:

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -136,6 +136,7 @@ def test_elb_create_elb(mock_get_properties, mock_elb_json, mock_wait_for_task, 
     mock_listener_policy.assert_called_with(mock_elb_json())
 
 
+@mock.patch.dict('foremast.elb.create_elb.DEFAULT_ELB_SECURITYGROUPS', {"dev": []})
 @mock.patch('foremast.elb.create_elb.get_vpc_id', return_value='vpc-100')
 @mock.patch('foremast.elb.create_elb.format_listeners')
 @mock.patch('foremast.elb.create_elb.get_subnets')

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -15,8 +15,9 @@
 #   limitations under the License.
 
 from configparser import ConfigParser
+from unittest.mock import patch
 
-from foremast.consts import ALLOWED_TYPES, extract_formats
+from foremast.consts import ALLOWED_TYPES, extract_formats, _generate_security_groups
 
 
 def test_consts_extract_formats():
@@ -38,3 +39,16 @@ def test_consts_pipeline_types():
     """Default types should be set."""
     assert 'ec2' in ALLOWED_TYPES
     assert 'lambda' in ALLOWED_TYPES
+
+
+@patch('foremast.consts.validate_key_values')
+def test_parse_security_group(values):
+    """Parse out security group entries"""
+    values.return_value = 'g1'
+    assert {'': ['g1']} == _generate_security_groups('default_ec2_securitygroups')
+
+    values.return_value = 'g1,g2'
+    assert {'': ['g1', 'g2']} == _generate_security_groups('default_ec2_securitygroups')
+
+    values.return_value = {'dev': ['g1', 'g2'], 'stage': ['g3']}
+    assert {'dev': ['g1', 'g2'], 'stage': ['g3']} == _generate_security_groups('default_ec2_securitygroups')

--- a/tests/test_consts.py
+++ b/tests/test_consts.py
@@ -50,5 +50,8 @@ def test_parse_security_group(values):
     values.return_value = 'g1,g2'
     assert {'': ['g1', 'g2']} == _generate_security_groups('default_ec2_securitygroups')
 
-    values.return_value = {'dev': ['g1', 'g2'], 'stage': ['g3']}
-    assert {'dev': ['g1', 'g2'], 'stage': ['g3']} == _generate_security_groups('default_ec2_securitygroups')
+
+@patch('foremast.consts.validate_key_values', return_value="{'': ['g3']}")
+def test_parse_security_group_dict(mock_keys):
+    """Validate security groups are handled properly if dictionary is in dyanmic config"""
+    assert {'': ['g3']} == _generate_security_groups('default_elb_securitygroups')


### PR DESCRIPTION
These changes allow to specific security groups for elb and ec2 instances per account.

Currently the only option is to set sg for all account. This gives a little more flexibility on what sg are added to a specific account.