### PR TITLE
Keep old s3 tags when new tags added.

### DIFF
--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -119,22 +119,24 @@ class S3Apps(object):
         """Regular put_bucket_tagging sets TagSet which overwrites old tags.
         Below logic keeps the old tags in place as well.
         """
-        app_group_tag = {'Key': 'app_group', 'Value': self.group}
-        app_name_tag = {'Key': 'app_name', 'Value': self.app_name}
-        name_tag_count, group_tag_count = 0, 0
         try:
             # Get current tags list, if no tags exist will get an exception.
             result = self.s3client.get_bucket_tagging(Bucket=self.bucket)['TagSet']
-            for item in result:
-                if 'app_group' in item['Key']:
-                    item.update(app_group_tag)
-                    group_tag_count += 1
-                elif 'app_name' in item['Key']:
-                    item.update(app_name_tag)
-                    name_tag_count += 1
         except ClientError as e:
             LOG.warning(e)
             result = []
+
+        app_group_tag = {'Key': 'app_group', 'Value': self.group}
+        app_name_tag = {'Key': 'app_name', 'Value': self.app_name}
+        name_tag_count, group_tag_count = 0, 0
+
+        for item in result:
+            if 'app_group' in item['Key']:
+                item.update(app_group_tag)
+                group_tag_count += 1
+            elif 'app_name' in item['Key']:
+                item.update(app_name_tag)
+                name_tag_count += 1
 
         # If app_group tag key does not exist add it.
         if group_tag_count == 0:

--- a/src/foremast/utils/generate_s3_tags.py
+++ b/src/foremast/utils/generate_s3_tags.py
@@ -1,0 +1,16 @@
+def generated_tag_data(tags):
+    """Gets normal dictionary then converts to S3 tag set list.
+
+    Args:
+        tags (dict): Dictonary of tag key and tag value passed.
+
+    Returns:
+        list: List of dictionaries.
+    """
+    generated_tags = []
+    for key, value in tags.items():
+        generated_tags.append({
+            'Key': key,
+            'Value': value,
+        })
+    return generated_tags

--- a/tests/s3/test_s3_tags.py
+++ b/tests/s3/test_s3_tags.py
@@ -1,0 +1,11 @@
+"""Test S3 tags result."""
+from foremast.utils import generate_s3_tags
+
+
+def test_s3_tags_data():
+    """Result data should be list then needs to have Key:key Value:value format."""
+    test_result = generate_s3_tags.generated_tag_data({'app_group': 'test_value'})
+
+    assert list == type(test_result)
+    assert 'app_group' == test_result[0]['Key']
+    assert 'test_value' == test_result[0]['Value']


### PR DESCRIPTION
There is a logic to add app_group, app_name tag. S3 api does put tagset which overwrites any other tags that exist in s3 bucket. This logic keeps old tags as well addition to app_group, app_name.