### PR TITLE
tests: Sanity check IAM Policy templates

### DIFF
--- a/src/foremast/iam/construct_policy.py
+++ b/src/foremast/iam/construct_policy.py
@@ -98,7 +98,7 @@ def render_policy_template(  # pylint: disable=R0913
 
     try:
         statement_block = json.loads(rendered_service_policy)
-        statements = statements.append(statement_block)
+        statements.append(statement_block)
     except ValueError:
         LOG.debug('Need to make %s template into list.', service)
         statements = json.loads('[{0}]'.format(rendered_service_policy))

--- a/src/foremast/iam/construct_policy.py
+++ b/src/foremast/iam/construct_policy.py
@@ -81,7 +81,7 @@ def render_policy_template(  # pylint: disable=R0913
             template.
 
     Returns:
-        list: :obj:`dict`
+        list: IAM Policy :obj:`dict` statements for the given service.
 
     """
     statements = []

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -24,6 +24,9 @@ from ..exceptions import ForemastTemplateNotFound
 
 LOG = logging.getLogger(__name__)
 
+HERE = os.path.dirname(os.path.realpath(__file__))
+LOCAL_TEMPLATES = '{0}/../templates/'.format(HERE)
+
 
 def get_template_object(template_file=''):
     """Get the Jinja2 template and returns Template object
@@ -34,15 +37,14 @@ def get_template_object(template_file=''):
     Returns:
         jinja2.Template: Template jinja2 object
     """
-    here = os.path.dirname(os.path.realpath(__file__))
-    local_templates = '{0}/../templates/'.format(here)
     jinja_lst = []
 
     if TEMPLATES_PATH:
         external_templates = os.path.expanduser(TEMPLATES_PATH)
         assert os.path.isdir(external_templates), 'Template path {0} not found'.format(external_templates)
         jinja_lst.append(external_templates)
-    jinja_lst.append(local_templates)
+
+    jinja_lst.append(LOCAL_TEMPLATES)
 
     jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_lst))
 

--- a/tests/iam/test_iam_valid_json.py
+++ b/tests/iam/test_iam_valid_json.py
@@ -1,0 +1,43 @@
+"""Test IAM Policy templates are valid JSON."""
+import jinja2
+
+from foremast.iam.construct_policy import render_policy_template
+from foremast.utils.templates import LOCAL_TEMPLATES
+
+
+def test_all_iam_templates():
+    """Verify all IAM templates render as proper JSON."""
+    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader([LOCAL_TEMPLATES]))
+
+    iam_templates = jinjaenv.list_templates(filter_func=lambda x: all([
+        x.startswith('infrastructure/iam/'),
+        'trust' not in x,
+        'wrapper' not in x, ]))
+
+    for template in iam_templates:
+        *_, service_json = template.split('/')
+        service, *_ = service_json.split('.')
+
+        items = ['resource1', 'resource2']
+
+        if service == 'rds-db':
+            items = {
+                'resource1': 'user1',
+                'resource2': 'user2',
+            }
+
+        rendered = render_policy_template(
+            account_number='',
+            app='coreforrest',
+            env='dev',
+            group='forrest',
+            items=items,
+            pipeline_settings={
+                'lambda': {
+                    'vpc_enabled': False,
+                },
+            },
+            region='us-east-1',
+            service=service)
+
+        assert isinstance(rendered, list)

--- a/tests/iam/test_iam_valid_json.py
+++ b/tests/iam/test_iam_valid_json.py
@@ -5,18 +5,19 @@ from foremast.iam.construct_policy import render_policy_template
 from foremast.utils.templates import LOCAL_TEMPLATES
 
 
-def test_all_iam_templates():
-    """Verify all IAM templates render as proper JSON."""
+def iam_templates():
+    """Generate list of IAM templates."""
     jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader([LOCAL_TEMPLATES]))
 
-    iam_templates = jinjaenv.list_templates(filter_func=lambda x: all([
+    iam_template_names = jinjaenv.list_templates(filter_func=lambda x: all([
         x.startswith('infrastructure/iam/'),
         'trust' not in x,
         'wrapper' not in x, ]))
 
-    for template in iam_templates:
-        *_, service_json = template.split('/')
-        service, *_ = service_json.split('.')
+    for iam_template_name in iam_template_names:
+        yield iam_template_name
+
+
 
         items = ['resource1', 'resource2']
 


### PR DESCRIPTION
We need a way to automatically validate any IAM Policy templates will render to JSON properly. We can come back to this in the future and move the logic to a `foremast validate templates iam` command or something.