### PR TITLE
fix: Allow access to DynamoDB table/name/stream/

### DIFF
--- a/src/foremast/templates/infrastructure/iam/dynamodb.json.j2
+++ b/src/foremast/templates/infrastructure/iam/dynamodb.json.j2
@@ -13,4 +13,22 @@
                 {%- endif -%}
             {% endfor %}
             ]
+        },
+        {
+            "Sid": "DynamoDBStreamRead",
+            "Action": [
+                "dynamodb:DescribeStream",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+                "dynamodb:ListStreams"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+            {%- for table in items %}
+                "arn:aws:dynamodb:{{ region }}:{{ account_number }}:table/{{ table }}/stream/*"
+                {%- if not loop.last -%}
+                ,
+                {%- endif -%}
+            {% endfor %}
+            ]
         }


### PR DESCRIPTION
For Lambda Functions to use DynamoDB as a Trigger, the IAM Role needs to have access to the `table/name/stream/` directory:
```
There was an error creating the trigger: Cannot access stream arn:aws:dynamodb:us-east-1:222572804561:table/name/stream/2017-07-28T18:53:40.930. Please ensure the role can perform the GetRecords, GetShardIterator, DescribeStream, and ListStreams Actions on your stream in IAM.
```