### PR TITLE
Fix issue creating security groups

### DIFF
--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -243,10 +243,11 @@ class SpinnakerSecurityGroup(object):
         ingress_rules = []
 
         try:
-            _ = get_security_group_id(name=self.app_name, env=self.env, region=self.region)
-            self.log.debug('Security Group ID %s found for %s.', _, self.app_name)
+            security_id = get_security_group_id(name=self.app_name, env=self.env, region=self.region)
         except (SpinnakerSecurityGroupError, AssertionError):
             self._create_security_group(ingress_rules)
+        else:
+            self.log.debug('Security Group ID %s found for %s.', security_id, self.app_name)
 
         try:
             ingress = self.update_default_rules()

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -243,6 +243,12 @@ class SpinnakerSecurityGroup(object):
         ingress_rules = []
 
         try:
+            _ = get_security_group_id(name=self.app_name, env=self.env, region=self.region)
+            self.log.debug('Security Group ID %s found for %s.', _, self.app_name)
+        except (SpinnakerSecurityGroupError, AssertionError):
+            self._create_security_group(ingress_rules)
+
+        try:
             ingress = self.update_default_rules()
         except KeyError:
             msg = 'Possible missing configuration for "{0}".'.format(self.env)

--- a/tests/test_securitygroup.py
+++ b/tests/test_securitygroup.py
@@ -57,9 +57,10 @@ def test_create_crossaccount_securitygroup(get_details, pipeline_config, wait_fo
     assert x.create_security_group() is True
 
 
+@mock.patch('foremast.securitygroup.create_securitygroup.get_security_group_id')
 @mock.patch('foremast.securitygroup.create_securitygroup.get_properties')
 @mock.patch("foremast.securitygroup.create_securitygroup.get_details")
-def test_missing_configuration(get_details, get_properties):
+def test_missing_configuration(get_details, get_properties, get_sec_id):
     """Make missing Security Group configurations more apparent."""
     get_properties.return_value = {}
 
@@ -69,9 +70,10 @@ def test_missing_configuration(get_details, get_properties):
         security_group.create_security_group()
 
 
+@mock.patch('foremast.securitygroup.create_securitygroup.get_security_group_id')
 @mock.patch('foremast.securitygroup.create_securitygroup.get_properties')
 @mock.patch("foremast.securitygroup.create_securitygroup.get_details")
-def test_misconfiguration(get_details, get_properties):
+def test_misconfiguration(get_details, get_properties, get_sec_id):
     """Make bad Security Group definitions more apparent."""
     get_properties.return_value = {'security_group': {}}
 


### PR DESCRIPTION
If we have self-referencing rules (aka `$self`) defined in `config.py`, then new apps will fail as there is a dependency loop going on. We can't create the sg since there is a rule referencing itself.

This changes the behavior on how we create security groups.

*New apps*
First create an sg, if none found
then update the sg with the new rules

*Existing apps*
Update sg with new rules