### PR TITLE
Feature/content encoding

### DIFF
--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -76,7 +76,11 @@
             "index_suffix": "index.html",
             "error_document": " "
         },
-        "set_content_encoding": false
+        "content_encodings": [
+            { "path": "",
+              "encoding": ""
+            }
+        ]
     },
     "datapipeline": {
         "description": "",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -76,11 +76,7 @@
             "index_suffix": "index.html",
             "error_document": " "
         },
-        "content_encodings": [
-            { "path": "",
-              "encoding": ""
-            }
-        ]
+        "content_encodings": []
     },
     "datapipeline": {
         "description": "",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -75,7 +75,8 @@
             "enabled": true,
             "index_suffix": "index.html",
             "error_document": " "
-        }
+        },
+        "set_content_encoding": false
     },
     "datapipeline": {
         "description": "",

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -76,7 +76,7 @@
             "index_suffix": "index.html",
             "error_document": " "
         },
-        "content_encodings": []
+        "content_metadata": []
     },
     "datapipeline": {
         "description": "",


### PR DESCRIPTION
Adds the ability to add content-encoding headings to specific directories on s3 deploy.

Example Config:

```
  "s3": {
      "shared_bucket_target": "s3-shared-testdevops",
       "content_encodings": [
           { "path": "app_compressed/pages",
             "encoding": "br"
           },
           { "path": "app_compressed_2",
             "encoding": "gzip"
           }
       ]
   }
```