### PR TITLE
Clean-up: Example S3 Bucket Name in Templates

### DIFF
--- a/src/foremast/templates/infrastructure/iam/s3.json.j2
+++ b/src/foremast/templates/infrastructure/iam/s3.json.j2
@@ -8,9 +8,11 @@
             ],
             "Resource": [
                 {% for bucket in items -%}
-                  "arn:aws:s3:::{{ bucket }}",
+                  "arn:aws:s3:::{{ bucket }}"
+                  {%- if not loop.last -%}
+                  ,
+                  {%- endif -%}
                 {% endfor -%}
-                "arn:aws:s3:::default_bucket_name"
             ]
         },
         {
@@ -24,8 +26,10 @@
             ],
             "Resource": [
                 {% for bucket in items -%}
-                  "arn:aws:s3:::{{ bucket }}/*",
+                  "arn:aws:s3:::{{ bucket }}/*"
+                  {%- if not loop.last -%}
+                  ,
+                  {%- endif -%}
                 {% endfor -%}
-                "arn:aws:s3:::default_bucket_name/*"
             ]
         }

--- a/tests/iam/test_iam_construct.py
+++ b/tests/iam/test_iam_construct.py
@@ -97,11 +97,11 @@ def test_construct_s3(requests_get, get_base_settings):
 
     assert len(allow_list_policy['Action']) == 3
     assert 's3:ListBucket' in allow_list_policy['Action']
-    assert len(allow_list_policy['Resource']) == 1
+    assert len(allow_list_policy['Resource']) == 0
 
     assert len(allow_edit_policy['Action']) == 5
     assert all(('s3:{0}Object'.format(action) in allow_edit_policy['Action'] for action in ('Delete', 'Get', 'Put')))
-    assert len(allow_edit_policy['Resource']) == 1
+    assert len(allow_edit_policy['Resource']) == 0
 
 
 @mock.patch('foremast.utils.credentials.API_URL', 'http://test.com')
@@ -126,9 +126,9 @@ def test_construct_s3_buckets(requests_get, get_base_settings):
 
     allow_list_policy, allow_edit_policy = policy['Statement']
 
-    assert len(allow_list_policy['Resource']) == 3
+    assert len(allow_list_policy['Resource']) == 2
 
-    assert len(allow_edit_policy['Resource']) == 3
+    assert len(allow_edit_policy['Resource']) == 2
 
 
 @mock.patch('foremast.utils.credentials.API_URL', 'http://test.com')


### PR DESCRIPTION
It appears the s3 template seems to have a reference so some example bucket. I can't find a reason for it to be there so I aligned it with the dynamodb.json template with the built in Jinja2 last feature.