### PR TITLE
fix: Return Task status, update docstrings

### DIFF
--- a/src/foremast/utils/tasks.py
+++ b/src/foremast/utils/tasks.py
@@ -63,7 +63,7 @@ def _check_task(taskid):
         taskid (str): Existing Spinnaker Task ID.
 
     Returns:
-        polls for task status.
+        str: Task status.
 
     """
     try:
@@ -103,7 +103,7 @@ def check_task(taskid, timeout=DEFAULT_TASK_TIMEOUT, wait=2):
         wait (int, optional): Seconds to pause between polling attempts.
 
     Returns:
-        polls for task status.
+        str: Task status.
 
     Raises:
         AssertionError: API did not respond with a 200 status code.
@@ -129,7 +129,7 @@ def wait_for_task(task_data):
         task_data (str): the task json to execute
 
     Returns:
-        polls for task status
+        str: Task status.
 
     """
     taskid = post_task(task_data)
@@ -148,4 +148,4 @@ def wait_for_task(task_data):
 
     LOG.debug("Task %s will timeout after %s", task_type, timeout)
 
-    check_task(taskid, timeout)
+    return check_task(taskid, timeout)

--- a/src/foremast/utils/tasks.py
+++ b/src/foremast/utils/tasks.py
@@ -27,13 +27,16 @@ LOG = logging.getLogger(__name__)
 
 
 def post_task(task_data):
-    """POST JSON to Spinnaker /tasks.
+    """Create Spinnaker Task.
 
     Args:
-        task_data (str): the task json that needs posted.
+        task_data (str): Task JSON definition.
 
     Returns:
-        str: taskid.
+        str: Spinnaker Task ID.
+
+    Raises:
+        AssertionError: Error response from Spinnaker.
 
     """
     url = '{}/tasks'.format(API_URL)
@@ -54,10 +57,10 @@ def post_task(task_data):
 
 
 def _check_task(taskid):
-    """Check task status.
+    """Check Spinnaker Task status.
 
     Args:
-        taskid (str): the task id returned from create_elb.
+        taskid (str): Existing Spinnaker Task ID.
 
     Returns:
         polls for task status.
@@ -95,17 +98,17 @@ def check_task(taskid, timeout=DEFAULT_TASK_TIMEOUT, wait=2):
     """Wrap check_task.
 
     Args:
-        taskid (str): the task id returned from post_task
-        timeout (int) (optional): how long to wait before failing the task
+        taskid (str): Existing Spinnaker Task ID.
+        timeout (int, optional): Consider Task failed after given seconds.
         wait (int, optional): Seconds to pause between polling attempts.
 
     Returns:
         polls for task status.
 
     Raises:
-        AssertionError: API did not responde with a 200 status code.
-        foremast.exceptions.SpinnakerTaskInconclusiveError: Task did not reach a
-            terminal state in the given time.
+        AssertionError: API did not respond with a 200 status code.
+        :obj:`foremast.exceptions.SpinnakerTaskInconclusiveError`: Task did not
+            reach a terminal state before the given time out.
 
     """
     max_attempts = int(timeout / wait)

--- a/src/foremast/utils/vpc.py
+++ b/src/foremast/utils/vpc.py
@@ -25,14 +25,20 @@ LOG = logging.getLogger(__name__)
 
 
 def get_vpc_id(account, region):
-    """Get vpc id.
+    """Get VPC ID configured for ``account`` in ``region``.
 
     Args:
         account (str): AWS account name.
         region (str): Region name, e.g. us-east-1.
 
     Returns:
-        str: ID for the requested _account_ in _region_.
+        str: VPC ID for the requested ``account`` in ``region``.
+
+    Raises:
+        :obj:`foremast.exceptions.SpinnakerVPCIDNotFound`: VPC ID not found for
+            ``account`` in ``region``.
+        :obj:`foremast.exceptions.SpinnakerVPCNotFound`: Spinnaker has no VPCs
+            configured.
 
     """
     url = '{0}/vpcs'.format(API_URL)


### PR DESCRIPTION
We should return something useful from checking a Task status. The most useful thing we have is the status result from the poller. Also, updating some old docstrings with more information.