### PR TITLE
added docs and missing trust template for rolling pipeline

### DIFF
--- a/_docs/configuration_files/pipeline_json/index.rst
+++ b/_docs/configuration_files/pipeline_json/index.rst
@@ -36,6 +36,7 @@ Specifies what type of pipeline to use for the application.
         - ``"lambda"`` - Sets up an AWS Lambda pipeline and infrastructure
         - ``"manual"`` - Create Pipelines from raw JSON, use with :ref:`pipeline_files`.
         - ``"s3"`` - Sets up an AWS S3 pipeline and infrastructure
+        - ``"rolling"`` - Sets up a "rolling" style pipeline. Requires custom templates.
 
 ``owner_email``
 ~~~~~~~~~~~~~~~

--- a/src/foremast/templates/infrastructure/iam/trust/rolling_role.json.j2
+++ b/src/foremast/templates/infrastructure/iam/trust/rolling_role.json.j2
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/src/foremast/utils/get_cloudwatch_event_rule.py
+++ b/src/foremast/utils/get_cloudwatch_event_rule.py
@@ -17,6 +17,8 @@ def get_cloudwatch_event_rule(app_name, account, region):
     rule_names = cloudwatch_client.list_rule_names_by_target(TargetArn=lambda_alias_arn)
 
     if rule_names['RuleNames']:
-        return rule_names['RuleNames']
+        all_rules = rule_names['RuleNames']
     else:
         LOG.debug("No event rules found")
+        all_rules = []
+    return all_rules


### PR DESCRIPTION
Just added small docs to note that rolling is a supported pipeline type and added a missing trust file for rolling pipelines. This is the same as the ec2 trust file. 