### PR TITLE
Disable scale down

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -237,6 +237,11 @@ scaling policy will be attached
 
    | *Type*: number
 
+``scale_down`` : Attach a default scale-down policy
+
+   | *Type*: boolean
+   | *Default*: ``true``
+
 ``period_minutes`` : Time period to look across for determining if threshold was
 met
 
@@ -265,7 +270,8 @@ was met
            "metric": "CPUUtilization",
            "threshold": 90,
            "period_minutes": 10,
-           "statistic": "Average"
+           "statistic": "Average",
+           "scale_down": true
        }
    }
 

--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -110,8 +110,10 @@ class AutoScalingPolicy:
             period_sec = int(self.settings['asg']['scaling_policy']['period_minutes']) * 60
         else:
             period_sec = 1800
+        
         self.prepare_policy_template('scale_up', period_sec, server_group)
-        self.prepare_policy_template('scale_down', period_sec, server_group)
+        if self.settings['asg']['scaling_policy'].get('scale_down', True):
+            self.prepare_policy_template('scale_down', period_sec, server_group)
 
     def get_server_group(self):
         """Finds the most recently deployed server group for the application.

--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -110,7 +110,7 @@ class AutoScalingPolicy:
             period_sec = int(self.settings['asg']['scaling_policy']['period_minutes']) * 60
         else:
             period_sec = 1800
-        
+
         self.prepare_policy_template('scale_up', period_sec, server_group)
         if self.settings['asg']['scaling_policy'].get('scale_down', True):
             self.prepare_policy_template('scale_down', period_sec, server_group)


### PR DESCRIPTION
This adds the ability to disable the scale-down policy. Default behavior remains the same. 