### PR TITLE
Add support for Glue and Athena to IAM Services block

### DIFF
--- a/_docs/configuration_files/pipeline_json/services.rest
+++ b/_docs/configuration_files/pipeline_json/services.rest
@@ -5,6 +5,14 @@ Access to different Cloud Services will be added to an inline Policy for an IAM
 Role. Keys must match with a corresponding template in
 :file:`src/foremast/templates/infrastructure/iam/{key}.json.j2`.
 
+``Athena``
+******************
+
+Add Athena Query access.
+
+   | *Type*: boolean
+   | *Default*: ``false``
+
 ``cloudformation``
 ******************
 
@@ -52,6 +60,14 @@ Add Firehose access to streams listed.
 
    | *Type*: array
    | *Default*: ``[]``
+
+``glue``
+******************
+
+Add Glue GetTable and GetDatabase access.
+
+   | *Type*: boolean
+   | *Default*: ``false``
 
 ``kinesis``
 ***********

--- a/_docs/configuration_files/pipeline_json/services.rest
+++ b/_docs/configuration_files/pipeline_json/services.rest
@@ -5,7 +5,7 @@ Access to different Cloud Services will be added to an inline Policy for an IAM
 Role. Keys must match with a corresponding template in
 :file:`src/foremast/templates/infrastructure/iam/{key}.json.j2`.
 
-``Athena``
+``athena``
 ******************
 
 Add Athena Query access.

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -20,7 +20,7 @@ from pprint import pformat
 
 import boto3
 
-from ..consts import DEFAULT_ELB_SECURITYGROUPS, SECURITYGROUP_REPLACEMENTS
+from ..consts import DEFAULT_ELB_SECURITYGROUPS
 from ..utils import get_properties, get_subnets, get_template, get_vpc_id, remove_duplicate_sg, wait_for_task
 from .format_listeners import format_listeners
 from .splay_health import splay_health

--- a/src/foremast/templates/infrastructure/iam/athena.json.j2
+++ b/src/foremast/templates/infrastructure/iam/athena.json.j2
@@ -1,0 +1,12 @@
+        {
+            "Sid": "AthenaLimitedAccess",
+            "Action": [
+                "athena:StartQueryExecution", 
+                "athena:StopQueryExecution", 
+                "athena:GetQueryExecution", 
+                "athena:GetQueryResults", 
+                "athena:RunQuery" 
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }

--- a/src/foremast/templates/infrastructure/iam/glue.json.j2
+++ b/src/foremast/templates/infrastructure/iam/glue.json.j2
@@ -1,0 +1,9 @@
+        {
+            "Sid": "GlueLimitedAccess",
+            "Action": [
+                "glue:GetTable*",
+                "glue:GetDatabase*"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }


### PR DESCRIPTION
Athena and Glue are a bit different as there is no resource based policies. Typically, you restrict the data behind the scenes with S3 permissions.

https://docs.aws.amazon.com/IAM/latest/UserGuide/list_athena.html
https://docs.aws.amazon.com/glue/latest/dg/api-permissions-reference.html