### PR TITLE
Added new tlscert_naming template format to allow support for ACM

### DIFF
--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -20,7 +20,7 @@ from pprint import pformat
 
 import boto3
 
-from ..consts import DEFAULT_ELB_SECURITYGROUPS, SECURITYGROUP_REPLACEMENTS
+from ..consts import DEFAULT_ELB_SECURITYGROUPS
 from ..utils import get_properties, get_subnets, get_template, get_vpc_id, remove_duplicate_sg, wait_for_task
 from .format_listeners import format_listeners
 from .splay_health import splay_health

--- a/src/foremast/elb/create_elb.py
+++ b/src/foremast/elb/create_elb.py
@@ -72,7 +72,7 @@ class SpinnakerELB:
         target = elb_settings.get('target', 'HTTP:80/health')
         health = splay_health(target)
 
-        listeners = format_listeners(elb_settings=elb_settings, env=self.env)
+        listeners = format_listeners(elb_settings=elb_settings, env=self.env, region=region)
 
         idle_timeout = elb_settings.get('idle_timeout', None)
         access_log = elb_settings.get('access_log', {})

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -83,7 +83,8 @@ def format_listeners(elb_settings=None, env='dev', region='us-east-1'):
 
     if 'ports' in elb_settings:
         for listener in elb_settings['ports']:
-            cert_name = format_cert_name(env=env, region=region, account=account, certificate=listener.get('certificate', None))
+            cert_name = format_cert_name(
+                env=env, region=region, account=account, certificate=listener.get('certificate', None))
 
             lb_proto, lb_port = listener['loadbalancer'].split(':')
             i_proto, i_port = listener['instance'].split(':')
@@ -193,6 +194,8 @@ def generate_custom_cert_name(env='', region='', account='', certificate=None):
         elif certificate in json.loads(rendered_template)['acm'][region][env]:
             cert_name = json.loads(rendered_template)['acm'][region][env][certificate]
         else:
-            LOG.error("Unable to find TLS certificate named %s under parent keys [ACM, IAM] %s in v2 TLS Cert Template.", certificate, env)
+            LOG.error(
+                "Unable to find TLS certificate named %s under parent keys [ACM, IAM] %s in v2 TLS Cert Template.",
+                certificate, env)
 
     return cert_name

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -23,7 +23,7 @@ from ..utils import get_env_credential, get_template
 LOG = logging.getLogger(__name__)
 
 
-def format_listeners(elb_settings=None, env='dev'):
+def format_listeners(elb_settings=None, env='dev', region='us-east-1'):
     """Format ELB Listeners into standard list.
 
     Args:
@@ -83,7 +83,7 @@ def format_listeners(elb_settings=None, env='dev'):
 
     if 'ports' in elb_settings:
         for listener in elb_settings['ports']:
-            cert_name = format_cert_name(env=env, account=account, certificate=listener.get('certificate', None))
+            cert_name = format_cert_name(env=env, region=region, account=account, certificate=listener.get('certificate', None))
 
             lb_proto, lb_port = listener['loadbalancer'].split(':')
             i_proto, i_port = listener['instance'].split(':')
@@ -127,7 +127,7 @@ def format_listeners(elb_settings=None, env='dev'):
     return listeners
 
 
-def format_cert_name(env='', account='', certificate=None):
+def format_cert_name(env='', account='', region='', certificate=None):
     """Format the SSL certificate name into ARN for ELB.
 
     Args:
@@ -146,7 +146,7 @@ def format_cert_name(env='', account='', certificate=None):
             LOG.info("Full ARN provided...skipping lookup.")
             cert_name = certificate
         else:
-            generated_cert_name = generate_custom_cert_name(env, account, certificate)
+            generated_cert_name = generate_custom_cert_name(env, region, account, certificate)
             if generated_cert_name:
                 LOG.info("Found generated certificate %s from template", generated_cert_name)
                 cert_name = generated_cert_name
@@ -159,7 +159,7 @@ def format_cert_name(env='', account='', certificate=None):
     return cert_name
 
 
-def generate_custom_cert_name(env='', account='', certificate=None):
+def generate_custom_cert_name(env='', region='', account='', certificate=None):
     """Generate a custom TLS Cert name based on a template.
 
     Args:
@@ -184,6 +184,15 @@ def generate_custom_cert_name(env='', account='', certificate=None):
     try:
         cert_name = json.loads(rendered_template)[env][certificate]
     except KeyError:
-        LOG.error("Unable to find TLS certificate named %s under %s in TLS Cert Template", certificate, env)
+        LOG.error("Unable to find TLS certificate named %s under %s in v1 TLS Cert Template.", certificate, env)
+
+    if cert_name is None:
+        LOG.info("Attempting v2 TLS Cert Lookup...")
+        if certificate in json.loads(rendered_template)['iam'][env]:
+            cert_name = json.loads(rendered_template)['iam'][env][certificate]
+        elif certificate in json.loads(rendered_template)['acm'][region][env]:
+            cert_name = json.loads(rendered_template)['acm'][region][env][certificate]
+        else:
+            LOG.error("Unable to find TLS certificate named %s under parent keys [ACM, IAM] %s in v2 TLS Cert Template.", certificate, env)
 
     return cert_name

--- a/src/foremast/elb/format_listeners.py
+++ b/src/foremast/elb/format_listeners.py
@@ -134,6 +134,7 @@ def format_cert_name(env='', account='', region='', certificate=None):
     Args:
         env (str): Account environment name
         account (str): Account number for ARN
+        region (str): AWS Region.
         certificate (str): Name of SSL certificate
 
     Returns:
@@ -165,6 +166,7 @@ def generate_custom_cert_name(env='', region='', account='', certificate=None):
 
     Args:
         env (str): Account environment name
+        region (str): AWS Region.
         account (str): Account number for ARN.
         certificate (str): Name of SSL certificate.
 

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -17,8 +17,6 @@
 import json
 from unittest import mock
 
-import io
-
 from foremast.elb import SpinnakerELB
 from foremast.elb.format_listeners import format_cert_name, format_listeners
 from foremast.elb.splay_health import splay_health

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -17,10 +17,53 @@
 import json
 from unittest import mock
 
+import io
+
 from foremast.elb import SpinnakerELB
 from foremast.elb.format_listeners import format_cert_name, format_listeners
 from foremast.elb.splay_health import splay_health
 
+SAMPLE_TLSCERT_V1_JSON = """
+{
+  "dev": {
+    "wildcard.example.com": "arn:aws:iam::123456789012:server-certificate/wildcard.example.com-2020-07-15",
+    "wildcard.dev.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+  },
+  "prod": {
+    "wildcard.example.com": "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15",
+    "wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555"
+  }
+}
+"""
+
+SAMPLE_TLSCERT_V2_JSON = """{
+  "iam": {
+    "dev": {
+      "wildcard.example.com": "arn:aws:iam::123456789012:server-certificate/wildcard.example.com-2020-07-15"
+    },
+    "prod": {
+      "wildcard.example.com": "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15"
+    }
+  },
+  "acm": {
+    "us-east-1": {
+      "dev": {
+        "wildcard.dev.example.com": "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+      },
+      "prod": {
+        "wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555"
+      }
+    },
+    "us-west-2": {
+      "dev": {
+        "wildcard.dev.example.com": "arn:aws:acm:us-west-2:123456789012:certificate/11111111-0000-2222-3333-555555555555"
+      },
+      "prod": {
+        "wildcard.prod.example.com": "arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555"
+      }
+    }
+  }
+}"""
 
 def test_elb_splay():
     """Splay should split Health Checks properly."""
@@ -118,8 +161,37 @@ def test_elb_format_cert_name():
     full_cert_name = 'arn:aws:123'
     assert full_cert_name == format_cert_name(certificate=full_cert_name)
 
-    compiled_cert = 'arn:aws:iam::dev:server-certificate/mycert1'
-    assert compiled_cert == format_cert_name(account='dev', certificate='mycert1')
+    compiled_cert = 'arn:aws:iam::123456789012:server-certificate/mycert1'
+    assert compiled_cert == format_cert_name(account='123456789012', certificate='mycert1')
+
+@mock.patch("foremast.elb.format_listeners.get_template")
+def test_elb_cert_name_v1(rendered_template):
+    """Tests the format_cert_name method when used with v1 template"""
+    rendered_template.return_value = SAMPLE_TLSCERT_V1_JSON
+
+    iam_cert = "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15"
+    assert iam_cert == format_cert_name(env='prod', account='210987654321', region='us-east-1', certificate='wildcard.example.com')
+
+    acm_cert = 'arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555'
+    assert acm_cert == format_cert_name(env='prod', account='210987654321', region='us-east-1', certificate='wildcard.prod.example.com')
+
+    acm_region_cert = 'arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555'
+    assert acm_region_cert == format_cert_name(env='prod', account='210987654321', region='us-west-2', certificate='wildcard.prod.example.com')
+
+
+@mock.patch("foremast.elb.format_listeners.get_template")
+def test_elb_cert_name_v2(rendered_template):
+    """Tests the format_cert_name method when used with v2 template"""
+    rendered_template.return_value = SAMPLE_TLSCERT_V2_JSON
+
+    iam_cert = "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15"
+    assert iam_cert == format_cert_name(env='prod', account='210987654321', region='us-east-1', certificate='wildcard.example.com')
+
+    acm_cert = 'arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555'
+    assert acm_cert == format_cert_name(env='prod', account='210987654321', region='us-east-1', certificate='wildcard.prod.example.com')
+
+    acm_region_cert = 'arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555'
+    assert acm_region_cert == format_cert_name(env='prod', account='210987654321', region='us-west-2', certificate='wildcard.prod.example.com')
 
 
 @mock.patch.object(SpinnakerELB, 'configure_attributes')

--- a/tests/elb/test_elb.py
+++ b/tests/elb/test_elb.py
@@ -31,7 +31,8 @@ SAMPLE_TLSCERT_V1_JSON = """
   },
   "prod": {
     "wildcard.example.com": "arn:aws:iam::210987654321:server-certificate/wildcard.example.com-2020-07-15",
-    "wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555"
+    "wildcard.prod.example.com": "arn:aws:acm:us-east-1:210987654321:certificate/11111111-2222-3333-4444-555555555555",
+    "wildcard.us-west-2.prod.example.com": "arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555"
   }
 }
 """
@@ -176,7 +177,7 @@ def test_elb_cert_name_v1(rendered_template):
     assert acm_cert == format_cert_name(env='prod', account='210987654321', region='us-east-1', certificate='wildcard.prod.example.com')
 
     acm_region_cert = 'arn:aws:acm:us-west-2:210987654321:certificate/11111111-0000-2222-3333-555555555555'
-    assert acm_region_cert == format_cert_name(env='prod', account='210987654321', region='us-west-2', certificate='wildcard.prod.example.com')
+    assert acm_region_cert == format_cert_name(env='prod', account='210987654321', region='us-west-2', certificate='wildcard.us-west-2.prod.example.com')
 
 
 @mock.patch("foremast.elb.format_listeners.get_template")


### PR DESCRIPTION
ACM creates certs per region, this change enables users to reference certs by friendly name instead of long ARN. In doing this, we need to have backwards compatibility for both the v1 format and v2. I attempt the lookup in the v1 format first, if not we fall back to v2. 

## Questions
1. Do we want to have an execution flag to default to v2 for internal teams to prevent conflicts? 
2. Working on Unit tests now.

## Sample Template JSON
```{
    "iam": {
        "stage": {
            "wildcard.example.com": "arn::::example"
        },
        "prod": {
            "wildcard.example.com": "arn:::::example"
        }
    },
    "acm": {
        "us-east-1": {
            "stage": {
                "wildcard.appgroup.example.com": "arn:acm:::example"
            },
            "prod": {
                "wildcard.appgroup.example.com": "arn:acm:::example"
            }
        },
        "us-west-2": {
            "stage": {
                "wildcard.appgroup.example.com": "arn:acm:::example"
            },
            "prod": {
                "wildcard.appgroup.example.com": "arn:acm:::example"
            }
        }
    },
    "prod": {
        "wildcard.legacyiam.example.com": "arn:iam:::example",
        "wildcard.legacyacm.example.com": "arn:acm:::example"
    }
}
``` 