### PR TITLE
fix: We should default the env to current one

### DIFF
--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -299,7 +299,7 @@ class SpinnakerSecurityGroup(object):
             end_port = rule.get('end_port')
             protocol = rule.get('protocol', 'tcp')
 
-            requested_cross_account = rule.get('env', None)
+            requested_cross_account = rule.get('env', self.env)
             if self.env == requested_cross_account:
                 # We are trying to use cross-account security group settings within the same account
                 # We should not allow this.


### PR DESCRIPTION
This fixes the following error introduced during refactoring:
```
Traceback (most recent call last):
  File "/tmp/workspace/pipes-pipeline-prepare/venv/bin/prepare-infrastructure", line 11, in <module>
    sys.exit(prepare_infrastructure())
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.6/site-packages/foremast/runner.py", line 252, in prepare_infrastructure
    runner.create_secgroups()
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.6/site-packages/foremast/runner.py", line 170, in create_secgroups
    sgobj.create_security_group()
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.6/site-packages/foremast/securitygroup/create_securitygroup.py", line 269, in create_security_group
    ingress_rule = self.create_ingress_rule(app, rule)
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.6/site-packages/foremast/securitygroup/create_securitygroup.py", line 310, in create_ingress_rule
    cross_account_vpc_id = get_vpc_id(cross_account_env, self.region)
  File "/tmp/workspace/pipes-pipeline-prepare/venv/lib/python3.6/site-packages/foremast/utils/vpc.py", line 60, in get_vpc_id
    raise SpinnakerVPCIDNotFound('No VPC available for {0} [{1}].'.format(account, region))
foremast.exceptions.SpinnakerVPCIDNotFound: No VPC available for None [us-east-1].
```

What is happening is that if `env` is not set, we were defaulting to `None`. The condition would end up in the `else` clause. When `get_vpc_id()` was called, the `cross_account_env` was `None` and would never match a VPC with that.
