### PR TITLE
refactor: Remove defined types in pipeline_wrapper

### DIFF
--- a/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
@@ -28,15 +28,9 @@
     }
   ],
   "stages": [
-    {% if data.app.deploy_type == "lambda" %}
-      {# coming soon {% include "pipeline/stage-tagger-lambda.json.j2" %}, #}
-    {% elif data.app.deploy_type == "s3" %}
-      {# coming soon {% include "pipeline/stage-tagger-s3.json.j2" %}, #}
-    {% elif data.app.deploy_type == "datapipeline" %}
-      {# coming soon {% include "pipeline/stage-tagger-s3.json.j2" %}, #}
-    {% else %}
-      {% include "pipeline/stage-bake.json.j2" %}
+    {% if data.app.deploy_type not in ["lambda", "s3", "datapipeline"] %}
+      {% include "pipeline/stage-bake.json.j2" %},
+      {% include "pipeline/stage-tagger.json.j2" %}
     {% endif %}
-
    ]
 }


### PR DESCRIPTION
We already have defined Pipeline types for lambda, s3 and datapipeline.