### PR TITLE
docs: Fix header for types option

### DIFF
--- a/_docs/configuration_files/foremast_config.rst
+++ b/_docs/configuration_files/foremast_config.rst
@@ -55,7 +55,7 @@ Foremast
     | *Required*: Yes
 
 ``types``
-~~~~~~~~~
+*********
 
 List of foremast managed Pipeline types to allow.
 


### PR DESCRIPTION
Fixes the alignment of the `types` option on this page:
http://foremast.readthedocs.io/en/latest/configuration_files/foremast_config.html