### PR TITLE
fix: Remove warning of example security groups

### DIFF
--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -49,8 +49,7 @@ from boto3.exceptions import botocore
 from ..consts import DEFAULT_SECURITYGROUP_RULES
 from ..exceptions import (ForemastConfigurationFileError, SpinnakerSecurityGroupCreationFailed,
                           SpinnakerSecurityGroupError)
-from ..utils import (get_details, get_properties, get_security_group_id, get_template, get_vpc_id, wait_for_task,
-                     warn_user)
+from ..utils import (get_details, get_properties, get_security_group_id, get_template, get_vpc_id, wait_for_task)
 
 
 class SpinnakerSecurityGroup(object):
@@ -255,12 +254,6 @@ class SpinnakerSecurityGroup(object):
 
         for app in ingress:
             rules = ingress[app]
-
-            if app in ('app_a', 'app_b'):
-                msg = ('Using "{0}" in your security group will be ignored. '
-                       'Please remove them to suppress this warning.').format(app)
-                warn_user(msg)
-                continue
 
             # Essentially we have two formats: simple, advanced
             # - simple: is just a list of ports


### PR DESCRIPTION
This removes the warning we have for apps using `app_a` and `app_b` in the security group section.

This warning has been in place for over a year and its about time we remove it.