### PR TITLE
Minor ASG Policy fixes

### DIFF
--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -82,11 +82,10 @@ class AutoScalingPolicy:
             template_kwargs['comparisonOperator'] = 'LessThanThreshold'
             template_kwargs['scalingAdjustment'] = -1
 
-        self.log.info('Rendering Scaling Policy Template: %s', template_kwargs)
         rendered_template = get_template(template_file='infrastructure/autoscaling_policy.json.j2', **template_kwargs)
-        self.log.debug(rendered_template)
+        self.log.info('Creating a %s policy in %s for %s', scaling_type, self.env, self.app)
         wait_for_task(rendered_template)
-        self.log.info('Successfully created scaling policy in %s', self.env)
+        self.log.info('Successfully created a %s policy in %s for %s', scaling_type, self.env, self.app)
 
     def create_policy(self):
         """Wrapper function. Gets the server group, sets sane defaults,

--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -147,7 +147,7 @@ class AutoScalingPolicy:
                 "region": self.region,
                 "provider": "aws",
                 "type": "deleteScalingPolicy",
-                "user": "pipes-autoscaling-policy"
+                "user": "foremast-autoscaling-policy"
             }]
         }
         wait_for_task(json.dumps(delete_dict))

--- a/src/foremast/autoscaling_policy/create_policy.py
+++ b/src/foremast/autoscaling_policy/create_policy.py
@@ -169,5 +169,5 @@ class AutoScalingPolicy:
             if servergroup['scalingPolicies'] and servergroup['asg']['autoScalingGroupName'] == server_group:
                 self.log.info("Found policies on %s", server_group)
                 scalingpolicies.append(servergroup['scalingPolicies'])
-        self.log.debug("scaling policys: %s", scalingpolicies)
+        self.log.debug("Scaling policies: %s", scalingpolicies)
         return scalingpolicies


### PR DESCRIPTION
This is mostly a cosmetic fix, however, it should help with troubleshooting issues.

Old view:
```
2018-01-29 14:49:34,886 [INFO] foremast.utils.banners:banner:39 - ================================================================================
2018-01-29 14:49:34,886 [INFO] foremast.utils.banners:banner:40 -                             Creating Scaling Policy                             
2018-01-29 14:49:34,886 [INFO] foremast.utils.banners:banner:41 - ================================================================================
2018-01-29 14:49:35,163 [INFO] foremast.autoscaling_policy.create_policy:get_all_existing:162 - Checking for existing scaling policy
2018-01-29 14:49:35,552 [INFO] foremast.autoscaling_policy.create_policy:get_all_existing:170 - Found policies on edgeforrest-v000
2018-01-29 14:49:35,553 [INFO] foremast.autoscaling_policy.create_policy:delete_existing_policy:138 - Deleting policy edgeforrest-CPUUtilization-increase on edgeforrest-v000
2018-01-29 14:49:35,712 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid a7896d81-4163-4415-bab2-6c6a89e50c53
2018-01-29 14:49:35,874 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:50:25,194 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid a7896d81-4163-4415-bab2-6c6a89e50c53
2018-01-29 14:50:25,377 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:50:25,378 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:85 - Rendering Scaling Policy Template: {'app': 'edgeforrest', 'env': 'prods', 'region': 'us-east-1', 'server_group': 'edgeforrest-v000', 'period_sec': 600, 'scaling_policy': {'metric': 'CPUUtilization', 'statistic': 'Average', 'threshold': 60, 'period_minutes': 10}, 'operation': 'increase', 'comparisonOperator': 'GreaterThanThreshold', 'scalingAdjustment': 1}
2018-01-29 14:50:25,410 [INFO] foremast.utils.templates:get_template:84 - Rendering template /home/saviles/data/git/github/foremast/src/foremast/utils/../templates/infrastructure/autoscaling_policy.json.j2
2018-01-29 14:50:25,580 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 143c2e41-4495-4035-8a5a-a21ad8e5daa3
2018-01-29 14:50:25,928 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:50:51,792 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 143c2e41-4495-4035-8a5a-a21ad8e5daa3
2018-01-29 14:50:51,949 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:50:51,949 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:89 - Successfully created scaling policy in prods
```


New output
```
2018-01-29 14:36:22,117 [INFO] foremast.utils.banners:banner:39 - ================================================================================
2018-01-29 14:36:22,117 [INFO] foremast.utils.banners:banner:40 -                             Creating Scaling Policy                             
2018-01-29 14:36:22,117 [INFO] foremast.utils.banners:banner:41 - ================================================================================
2018-01-29 14:36:22,294 [INFO] foremast.autoscaling_policy.create_policy:get_all_existing:165 - Checking for existing scaling policy
2018-01-29 14:36:22,513 [INFO] foremast.autoscaling_policy.create_policy:get_all_existing:173 - Found policies on edgeforrest-v000
2018-01-29 14:36:22,514 [INFO] foremast.autoscaling_policy.create_policy:delete_existing_policy:140 - Deleting policy edgeforrest-CPUUtilization-decrease on edgeforrest-v000
2018-01-29 14:36:22,678 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 11de7bf0-2c21-4346-98d1-9a83da6eb4e0
2018-01-29 14:36:22,807 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:36:38,048 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
2018-01-29 14:36:40,051 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 11de7bf0-2c21-4346-98d1-9a83da6eb4e0
2018-01-29 14:36:40,216 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:36:40,216 [INFO] foremast.autoscaling_policy.create_policy:delete_existing_policy:140 - Deleting policy edgeforrest-CPUUtilization-increase on edgeforrest-v000
2018-01-29 14:36:40,386 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 5fbf7d98-5099-48a3-96b4-b5d459748d66
2018-01-29 14:36:40,553 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:36:55,608 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 5fbf7d98-5099-48a3-96b4-b5d459748d66
2018-01-29 14:36:55,774 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:36:55,800 [INFO] foremast.utils.templates:get_template:86 - Rendering template /home/saviles/data/git/github/foremast/src/foremast/utils/../templates/infrastructure/autoscaling_policy.json.j2
2018-01-29 14:36:55,800 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:86 - Creating a scale_up policy in prods for edgeforrest
2018-01-29 14:36:55,926 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 8ebb2789-d134-4db6-a8f5-f86c5c573cba
2018-01-29 14:36:56,094 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:37:35,076 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 8ebb2789-d134-4db6-a8f5-f86c5c573cba
2018-01-29 14:37:35,240 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:37:35,241 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:88 - Successfully created a scale_up policy in prods for edgeforrest
2018-01-29 14:37:35,265 [INFO] foremast.utils.templates:get_template:86 - Rendering template /home/saviles/data/git/github/foremast/src/foremast/utils/../templates/infrastructure/autoscaling_policy.json.j2
2018-01-29 14:37:35,265 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:86 - Creating a scale_down policy in prods for edgeforrest
2018-01-29 14:37:35,402 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 1d2bca3c-0a98-4e00-b05a-1531a3a60877
2018-01-29 14:37:35,564 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: RUNNING
...
2018-01-29 14:38:01,467 [INFO] foremast.utils.tasks:_check_task:76 - Checking taskid 1d2bca3c-0a98-4e00-b05a-1531a3a60877
2018-01-29 14:38:01,609 [INFO] foremast.utils.tasks:_check_task:87 - Current task status: SUCCEEDED
2018-01-29 14:38:01,609 [INFO] foremast.autoscaling_policy.create_policy:prepare_policy_template:88 - Successfully created a scale_down policy in prods for edgeforrest
```