### PR TITLE
fix: Use fully qualified path to file

### DIFF
--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -44,17 +44,17 @@ def get_template_object(template_file=''):
             is not available.
 
     """
-    jinja_lst = []
+    jinja_template_paths_obj = []
 
     if TEMPLATES_PATH:
         external_templates = pathlib.Path(TEMPLATES_PATH).expanduser().resolve()
         assert os.path.isdir(external_templates), 'External template path "{0}" not found'.format(external_templates)
-        jinja_lst.append(external_templates)
+        jinja_template_paths_obj.append(external_templates)
 
-    jinja_lst.append(LOCAL_TEMPLATES)
-    jinja_templates = [str(path) for path in jinja_lst]
+    jinja_template_paths_obj.append(LOCAL_TEMPLATES)
+    jinja_template_paths = [str(path) for path in jinja_template_paths_obj]
 
-    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_templates))
+    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_template_paths))
 
     try:
         template = jinjaenv.get_template(template_file)

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -25,8 +25,8 @@ from ..exceptions import ForemastTemplateNotFound
 
 LOG = logging.getLogger(__name__)
 
-HERE = os.path.dirname(os.path.realpath(__file__))
-LOCAL_TEMPLATES = pathlib.Path('{0}/../templates/'.format(HERE)).resolve()
+HERE = pathlib.Path(__file__).parent.absolute()
+LOCAL_TEMPLATES = HERE.joinpath('../templates/').resolve()
 
 
 def get_template_object(template_file=''):

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -16,6 +16,7 @@
 """Render Jinja2 template."""
 import logging
 import os
+import pathlib
 
 import jinja2
 
@@ -25,7 +26,7 @@ from ..exceptions import ForemastTemplateNotFound
 LOG = logging.getLogger(__name__)
 
 HERE = os.path.dirname(os.path.realpath(__file__))
-LOCAL_TEMPLATES = '{0}/../templates/'.format(HERE)
+LOCAL_TEMPLATES = str(pathlib.Path('{0}/../templates/'.format(HERE)).resolve())
 
 
 def get_template_object(template_file=''):
@@ -46,7 +47,7 @@ def get_template_object(template_file=''):
     jinja_lst = []
 
     if TEMPLATES_PATH:
-        external_templates = os.path.expanduser(TEMPLATES_PATH)
+        external_templates = str(pathlib.Path(TEMPLATES_PATH).expanduser().resolve())
         assert os.path.isdir(external_templates), 'External template path "{0}" not found'.format(external_templates)
         jinja_lst.append(external_templates)
 

--- a/src/foremast/utils/templates.py
+++ b/src/foremast/utils/templates.py
@@ -26,7 +26,7 @@ from ..exceptions import ForemastTemplateNotFound
 LOG = logging.getLogger(__name__)
 
 HERE = os.path.dirname(os.path.realpath(__file__))
-LOCAL_TEMPLATES = str(pathlib.Path('{0}/../templates/'.format(HERE)).resolve())
+LOCAL_TEMPLATES = pathlib.Path('{0}/../templates/'.format(HERE)).resolve()
 
 
 def get_template_object(template_file=''):
@@ -47,13 +47,14 @@ def get_template_object(template_file=''):
     jinja_lst = []
 
     if TEMPLATES_PATH:
-        external_templates = str(pathlib.Path(TEMPLATES_PATH).expanduser().resolve())
+        external_templates = pathlib.Path(TEMPLATES_PATH).expanduser().resolve()
         assert os.path.isdir(external_templates), 'External template path "{0}" not found'.format(external_templates)
         jinja_lst.append(external_templates)
 
     jinja_lst.append(LOCAL_TEMPLATES)
+    jinja_templates = [str(path) for path in jinja_lst]
 
-    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_lst))
+    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader(jinja_templates))
 
     try:
         template = jinjaenv.get_template(template_file)

--- a/tests/iam/test_iam_valid_json.py
+++ b/tests/iam/test_iam_valid_json.py
@@ -10,7 +10,7 @@ from foremast.utils.templates import LOCAL_TEMPLATES
 
 def iam_templates():
     """Generate list of IAM templates."""
-    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader([LOCAL_TEMPLATES]))
+    jinjaenv = jinja2.Environment(loader=jinja2.FileSystemLoader([str(LOCAL_TEMPLATES)]))
 
     iam_template_names = jinjaenv.list_templates(filter_func=lambda x: all([
         x.startswith('infrastructure/iam/'),


### PR DESCRIPTION
We should show the fully qualified path of the templates that are used.

Old
```
2018-01-29 15:29:18,160 [INFO] foremast.utils.templates:get_template:84 - Rendering template /data/git/github/foremast/src/foremast/utils/../templates/infrastructure/autoscaling_policy.json.j2
```

New
```
2018-01-29 15:22:15,280 [INFO] foremast.utils.templates:get_template:86 - Rendering template /data/git/github/foremast/src/foremast/templates/infrastructure/autoscaling_policy.json.j2
```