### PR TITLE
pass all pipeline data to wrapper creation

### DIFF
--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -127,6 +127,7 @@ class SpinnakerPipeline:
                 'slack': slack,
                 'root_volume_size': root_volume_size,
                 'ami_template_file': ami_template_file,
+                'pipeline': self.settings['pipeline']
             },
             'id': pipeline_id
         }


### PR DESCRIPTION
We do this with stage creation but I need this data during wrapper creation as well so that we can disable a trigger.

This just passes everything in `pipeline.json` to wrapper creation so that extra fields can be added without touching foremast source in the future. 