### PR TITLE
Add support for combining region specific configs

### DIFF
--- a/src/foremast/configs/prepare_configs.py
+++ b/src/foremast/configs/prepare_configs.py
@@ -95,7 +95,7 @@ def apply_region_configs(env_config):
     all values under a region
 
     Args:
-        env_config (dict): The environ
+        env_config (dict): The environment specific config.
 
     Return:
         dict: Newly updated dictionary with region overrides applied.

--- a/src/foremast/configs/prepare_configs.py
+++ b/src/foremast/configs/prepare_configs.py
@@ -93,14 +93,14 @@ def process_configs(file_lookup, app_config_format, pipeline_config):
 def apply_region_configs(env_config):
     """Override default env configs with region specific configs and nest
     all values under a region
-    
+
     Args:
         env_config (dict): The environ
-    
+
     Return:
         dict: Newly updated dictionary with region overrides applied.
     """
-    new_config = env_config.copy() 
+    new_config = env_config.copy()
     for region in env_config.get('regions', REGIONS):
         if isinstance(env_config.get('regions'), dict):
             region_specific_config = env_config['regions'][region]

--- a/src/foremast/templates/configs/configs.json.j2
+++ b/src/foremast/templates/configs/configs.json.j2
@@ -48,9 +48,9 @@
     },
     "qe": {
     },
-    "regions": [
-        "us-east-1"
-    ],
+    "regions": {
+        "us-east-1": {}
+    },
     "deploy_strategy": "highlander",
     "security_group": {
         "description": "Auto-Gen SG for {{ app }}",

--- a/tests/configs/test_prepare_configs.py
+++ b/tests/configs/test_prepare_configs.py
@@ -1,0 +1,110 @@
+"""Verifies that instance_links are being retrieved properly from LINKS. Verifies that app_data.json.j2
+contains the instance link information"""
+from unittest import mock
+from foremast import configs
+
+TEST_CONFIG =  { 
+    "asg": {
+        "subnet_purpose": "internal",
+        "min_inst": 3,
+        "max_inst": 3
+    },
+    "regions": {
+        "us-east-1": {},
+        "us-west-2": {
+            "asg": {
+                "min_inst": 1,
+                "max_inst": 1
+            }
+        }
+    }
+}
+
+def test_appy_region_configs():
+    """Tests that `configs.apply_region_configs` applies
+    region specific overrides correctly""" 
+    desired_config = { 
+        "asg": {
+            "subnet_purpose": "internal",
+            "min_inst": 3,
+            "max_inst": 3
+        },
+        "regions": {
+            "us-east-1": {},
+            "us-west-2": {
+                "asg": {
+                    "min_inst": 1,
+                    "max_inst": 1
+                }
+            }
+        },
+        "us-east-1": { 
+            "asg": {
+                "subnet_purpose": "internal",
+                "min_inst": 3,
+                "max_inst": 3
+            },
+            "regions": {
+                "us-east-1": {},
+                "us-west-2": {
+                    "asg": {
+                        "min_inst": 1,
+                        "max_inst": 1
+                    }
+                }
+            }
+        },
+        "us-west-2": { 
+            "asg": {
+                "subnet_purpose": "internal",
+                "min_inst": 1,
+                "max_inst": 1
+            },
+            "regions": {
+                "us-east-1": {},
+                "us-west-2": {
+                    "asg": {
+                        "min_inst": 1,
+                        "max_inst": 1
+                    }
+                }
+            }
+        }
+    }
+    rendered_config = configs.apply_region_configs(TEST_CONFIG)
+    assert rendered_config == desired_config
+
+def test_legacy_region_format():
+    """Validates that the only regions list format continues to work."""
+    desired_config = {
+        "asg": {
+            "subnet_purpose": "internal",
+            "min_inst": 3,
+            "max_inst": 3
+        },
+        "regions": ["us-east-1", "us-west-2"],
+        "us-east-1": {
+            "asg": {
+                "subnet_purpose": "internal",
+                "min_inst": 3,
+                "max_inst": 3
+            },
+            "regions": ["us-east-1", "us-west-2"],
+        },
+        "us-west-2": {
+            "asg": {
+                "subnet_purpose": "internal",
+                "min_inst": 3,
+                "max_inst": 3
+            },
+            "regions": ["us-east-1", "us-west-2"],
+        },
+    }
+    legacy_config = TEST_CONFIG.copy()
+    legacy_config["regions"] = ['us-east-1', 'us-west-2']
+    rendered_config = configs.apply_region_configs(legacy_config)
+    assert rendered_config == desired_config
+
+
+
+    


### PR DESCRIPTION
This PR adds support for overlaying region specific configs but also keeps all backwards compatibility. From this PR, nothing uses the region specific configs and those will come in a latter update. This PR also abstracted out some logic from the `process_git_configs` and `process_runway_configs` functions. These were almost identical so I moved them under a shared function to reduce duplicate code. 

Examples of new configs:

Below config is the application-master-stage.json for an app. min_inst and max_inst should be different for us-west-2. 
```{
  "security_group": {
    "description": "something useful",
    "elb_extras": [],
    "instance_extras": ["offices_all", "sumologic"]
  },
  "app": {
    "instance_type": "t2.small",
    "app_description": "Edge Forrest Demo application",
    "instance_profile": "forrest_edge_profile",
    "canary": "simple",
    "aca": [
      {"system.cpu.percent": "under(100)", "app.stage.purchases_min": "over(50)" }
    ]
  },
  "elb": {
    "subnet_purpose": "internal",
    "target": "TCP:8080",
    "ports": [
      {"loadbalancer": "HTTP:80", "instance": "HTTP:8080"}
    ]
  },
  "asg": {
    "subnet_purpose": "internal",
    "min_inst": 3,
    "max_inst": 3
  },
  "deployment": "spinnaker",
  "ticketid": "PSOBAT-710",
  "dns" : {
    "ttl": 120
    },
  "regions": {
    "us-east-1": {},
    "us-west-2": {
        "asg": {
            "min_inst": 1,
            "max_inst": 1
        }
    }
  }
}
```

Once rendered, this ends up looking like:

```
'stage': {'app': {'aca': [{'app.stage.purchases_min': 'over(50)',
                            'system.cpu.percent': 'under(100)'}],
                   'app_description': 'Edge Forrest Demo application',
                   'canary': 'simple',
                   'email': None,
                   'eureka_enabled': False,
                   'instance_profile': 'forrest_edge_profile',
                   'instance_type': 't2.small',
                   'lambda_environment': {},
                   'lambda_memory': '128',
                   'lambda_timeout': '30'},
           'asg': {'app_grace_period': 0,
                   'enable_public_ips': None,
                   'hc_grace_period': 180,
                   'hc_type': 'ELB',
                   'max_inst': 3,
                   'min_inst': 3,
                   'provider_healthcheck': {'amazon': False},
                   'scaling_policy': {},
                   'ssh_keypair': None,
                   'subnet_purpose': 'internal'},
           'datapipeline': {'activate_on_deploy': False,
                            'description': '',
                            'json_definition': {}},
           'deploy_strategy': 'highlander',
           'deployment': 'spinnaker',
           'dns': {'failover_dns': True, 'region_specific': True, 'ttl': 120},
           'elb': {'backend_policies': [],
                   'certificate': None,
                   'health': {'interval': 20,
                              'threshold': 2,
                              'timeout': 10,
                              'unhealthy_threshold': 5},
                   'i_port': 8080,
                   'i_proto': 'HTTP',
                   'lb_port': 80,
                   'lb_proto': 'HTTP',
                   'listener_policies': [],
                   'policies': [],
                   'ports': [{'instance': 'HTTP:8080',
                              'loadbalancer': 'HTTP:80'}],
                   'subnet_purpose': 'internal',
                   'target': 'TCP:8080'},
           'lambda_triggers': [],
           'qe': {},
           'regions': {'us-east-1': {},
                       'us-west-2': {'asg': {'max_inst': 1, 'min_inst': 1}}},
           's3': {'bucket_acl': 'private',
                  'bucket_policy': {},
                  'content_metadata': [],
                  'path': '/',
                  'website': {'enabled': True,
                              'error_document': ' ',
                              'index_suffix': 'index.html'}},
           'security_group': {'description': 'something useful',
                              'egress': '0.0.0.0/0',
                              'elb_extras': [],
                              'ingress': {},
                              'instance_extras': ['offices_all', 'sumologic']},
           'ticketid': 'PSOBAT-710',
           'us-east-1': {'app': {'aca': [{'app.stage.purchases_min': 'over(50)',
                                          'system.cpu.percent': 'under(100)'}],
                                 'app_description': 'Edge Forrest Demo '
                                                    'application',
                                 'canary': 'simple',
                                 'instance_profile': 'forrest_edge_profile',
                                 'instance_type': 't2.small'},
                         'asg': {'max_inst': 3,
                                 'min_inst': 3,
                                 'subnet_purpose': 'internal'},
                         'deployment': 'spinnaker',
                         'dns': {'ttl': 120},
                         'elb': {'ports': [{'instance': 'HTTP:8080',
                                            'loadbalancer': 'HTTP:80'}],
                                 'subnet_purpose': 'internal',
                                 'target': 'TCP:8080'},
                         'regions': {'us-east-1': {},
                                     'us-west-2': {'asg': {'max_inst': 1,
                                                           'min_inst': 1}}},
                         'security_group': {'description': 'something useful',
                                            'elb_extras': [],
                                            'instance_extras': ['offices_all',
                                                                'sumologic']},
                         'ticketid': 'PSOBAT-710'},
           'us-west-2': {'app': {'aca': [{'app.stage.purchases_min': 'over(50)',
                                          'system.cpu.percent': 'under(100)'}],
                                 'app_description': 'Edge Forrest Demo '
                                                    'application',
                                 'canary': 'simple',
                                 'instance_profile': 'forrest_edge_profile',
                                 'instance_type': 't2.small'},
                         'asg': {'max_inst': 1,
                                 'min_inst': 1,
                                 'subnet_purpose': 'internal'},
                         'deployment': 'spinnaker',
                         'dns': {'ttl': 120},
                         'elb': {'ports': [{'instance': 'HTTP:8080',
                                            'loadbalancer': 'HTTP:80'}],
                                 'subnet_purpose': 'internal',
                                 'target': 'TCP:8080'},
                         'regions': {'us-east-1': {},
                                     'us-west-2': {'asg': {'max_inst': 1,
                                                           'min_inst': 1}}},
                         'security_group': {'description': 'something useful',
                                            'elb_extras': [],
                                            'instance_extras': ['offices_all',
                                                                'sumologic']},
                         'ticketid': 'PSOBAT-710'}}}
```


In the rendered, you can see all contents are also nested under `us-east-1` or `us-west-2` keys, and that `us-west-2` has the `asg` changes specific to that region. 