### PR TITLE
disabled trigger for other pipelines besides just ec2

### DIFF
--- a/src/foremast/pipeline/create_pipeline_datapipeline.py
+++ b/src/foremast/pipeline/create_pipeline_datapipeline.py
@@ -63,6 +63,7 @@ class SpinnakerPipelineDataPipeline(SpinnakerPipeline):
                 'triggerjob': self.trigger_job,
                 'email': email,
                 'slack': slack,
+                'pipeline': self.settings['pipeline']
             },
             'id': pipeline_id
         }

--- a/src/foremast/pipeline/create_pipeline_lambda.py
+++ b/src/foremast/pipeline/create_pipeline_lambda.py
@@ -66,6 +66,7 @@ class SpinnakerPipelineLambda(SpinnakerPipeline):
                 'triggerjob': self.trigger_job,
                 'email': email,
                 'slack': slack,
+                'pipeline': self.settings['pipeline']
             },
             'id': pipeline_id
         }

--- a/src/foremast/pipeline/create_pipeline_s3.py
+++ b/src/foremast/pipeline/create_pipeline_s3.py
@@ -66,6 +66,7 @@ class SpinnakerPipelineS3(SpinnakerPipeline):
                 'triggerjob': self.trigger_job,
                 'email': email,
                 'slack': slack,
+                'pipeline': self.settings['pipeline']
             },
             'id': pipeline_id
         }


### PR DESCRIPTION
This was added for ec2 pipelines in https://github.com/gogoair/foremast/pull/266 but forgot to update it in the other pipeline types. 