### PR TITLE
Use gitlab v4 api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ boto3
 gogo-utils
 jinja2
 murl
-pyapi-gitlab
+python-gitlab
 requests
 tryagain
 slacker
-

--- a/src/foremast/configs/prepare_configs.py
+++ b/src/foremast/configs/prepare_configs.py
@@ -37,7 +37,8 @@ def process_git_configs(git_short=''):
     LOG.info('Processing application.json files from GitLab "%s".', git_short)
     file_lookup = FileLookup(git_short=git_short)
     app_configs = process_configs(file_lookup, 'runway/application-master-{env}.json', 'runway/pipeline.json')
-    config_commit = file_lookup.server.getbranch(file_lookup.project_id, 'master')['commit']['id']
+    commit_obj = file_lookup.project.commits.get('master')
+    config_commit = commit_obj.attributes.get('id')
     LOG.info('Commit ID used: %s', config_commit)
     app_configs['pipeline']['config_commit'] = config_commit
     return app_configs

--- a/src/foremast/configs/prepare_configs.py
+++ b/src/foremast/configs/prepare_configs.py
@@ -38,7 +38,7 @@ def process_git_configs(git_short=''):
     file_lookup = FileLookup(git_short=git_short)
     app_configs = process_configs(file_lookup, 'runway/application-master-{env}.json', 'runway/pipeline.json')
     commit_obj = file_lookup.project.commits.get('master')
-    config_commit = commit_obj.attributes.get('id')
+    config_commit = commit_obj.attributes['id']
     LOG.info('Commit ID used: %s', config_commit)
     app_configs['pipeline']['config_commit'] = config_commit
     return app_configs

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -65,7 +65,7 @@ def _get_ami_file(region='us-east-1'):
     project = server.projects.get('devops/ansible')
     ami_blob = project.files.get(file_path='scripts/{0}.json'.format(region), ref='master')
 
-    ami_contents = b64decode(ami_blob.decode()).decode()
+    ami_contents = ami_blob.decode().decode()
     LOG.debug('AMI File contents: %s', ami_contents)
     return ami_contents
 

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -98,12 +98,11 @@ class FileLookup():
         self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
 
         self.server = None
-        self.project_id = ''
 
         if not self.runway_dir:
-            self.get_gitlab_project_id()
+            self.get_gitlab_project()
 
-    def get_gitlab_project_id(self):
+    def get_gitlab_project(self):
         """Get numerical GitLab Project ID.
 
         Returns:

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -61,12 +61,10 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
 def _get_ami_file(region='us-east-1'):
     """Get file from Gitlab."""
     LOG.info("Getting AMI from Gitlab")
-    server = gitlab.Gitlab(GIT_URL, private_token=GITLAB_TOKEN, api_version=4)
-    project = server.projects.get('devops/ansible')
-    ami_blob = project.files.get(file_path='scripts/{0}.json'.format(region), ref='master')
-
-    ami_contents = ami_blob.decode().decode()
-    LOG.debug('AMI File contents: %s', ami_contents)
+    lookup = FileLookup(git_short='devops/ansible')
+    filename = 'scripts/{0}.json'.format(region)
+    ami_contents = lookup.remote_file(filename=filename, branch='master')
+    LOG.debug('AMI file contents in %s: %s', filename, ami_contents)
     return ami_contents
 
 

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -43,11 +43,7 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
 
     """
     if AMI_JSON_URL:
-        LOG.info("Getting AMI from %s", AMI_JSON_URL)
-        response = requests.get(AMI_JSON_URL)
-        assert response.ok, "Error getting ami info from {}".format(AMI_JSON_URL)
-
-        ami_dict = response.json()
+        ami_dict = _get_ami_json(AMI_JSON_URL)
         LOG.debug('Lookup AMI table: %s', ami_dict)
         ami_id = ami_dict[region][name]
     elif GITLAB_TOKEN:
@@ -73,6 +69,15 @@ def _get_ami_file(region='us-east-1'):
 
     ami_contents = b64decode(ami_blob.decode()).decode()
     return ami_contents
+
+
+def _get_ami_json(json_url):
+    """Helper function to get ami from a web url."""
+    LOG.info("Getting AMI from %s", json_url)
+    response = requests.get(json_url)
+    assert response.ok, "Error getting ami info from {}".format(json_url)
+    ami_dict = response.json()
+    return ami_dict
 
 
 class FileLookup():

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -44,7 +44,7 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
 
     """
     if AMI_JSON_URL:
-        ami_dict = _get_ami_json(AMI_JSON_URL)
+        ami_dict = _get_ami_dict(AMI_JSON_URL)
         ami_id = ami_dict[region][name]
     elif GITLAB_TOKEN:
         warn_user('Use AMI_JSON_URL feature instead.')
@@ -60,7 +60,15 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
 
 
 def _get_ami_file(region='us-east-1'):
-    """Get file from Gitlab."""
+    """Get file from Gitlab.
+
+    Args:
+        region (str): AWS Region to find AMI ID.
+
+    Returns:
+        str: Contents in json format.
+
+    """
     LOG.info("Getting AMI from Gitlab")
     lookup = FileLookup(git_short='devops/ansible')
     filename = 'scripts/{0}.json'.format(region)
@@ -69,8 +77,16 @@ def _get_ami_file(region='us-east-1'):
     return ami_contents
 
 
-def _get_ami_json(json_url):
-    """Get ami from a web url."""
+def _get_ami_dict(json_url):
+    """Get ami from a web url.
+
+    Args:
+        region (str): AWS Region to find AMI ID.
+
+    Returns:
+        dict: Contents in dictionary format.
+
+    """
     LOG.info("Getting AMI from %s", json_url)
     response = requests.get(json_url)
     assert response.ok, "Error getting ami info from {}".format(json_url)

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -97,6 +97,7 @@ class FileLookup():
         self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
 
         self.server = None
+        self.project = None
 
         if not self.runway_dir:
             self.get_gitlab_project()

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -52,12 +52,7 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
         ami_id = ami_dict[region][name]
     elif GITLAB_TOKEN:
         # TODO: Remove GitLab repository in favour of JSON URL option.
-        LOG.info("Getting AMI from Gitlab")
-        server = gitlab.Gitlab(GIT_URL, private_token=GITLAB_TOKEN, api_version=4)
-        project = server.projects.get('devops/ansible')
-        ami_blob = project.files.get(file_path='scripts/{0}.json'.format(region), ref='master')
-
-        ami_contents = b64decode(ami_blob.content).decode()
+        ami_contents = _get_ami_file(region=region)
         ami_dict = json.loads(ami_contents)
         LOG.debug('Lookup AMI table: %s', ami_dict)
         ami_id = ami_dict[name]
@@ -67,6 +62,17 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
     LOG.info('Using AMI: %s', ami_id)
 
     return ami_id
+
+
+def _get_ami_file(region='us-east-1'):
+    """Helper function to get file from Gitlab."""
+    LOG.info("Getting AMI from Gitlab")
+    server = gitlab.Gitlab(GIT_URL, private_token=GITLAB_TOKEN, api_version=4)
+    project = server.projects.get('devops/ansible')
+    ami_blob = project.files.get(file_path='scripts/{0}.json'.format(region), ref='master')
+
+    ami_contents = b64decode(ami_blob.decode()).decode()
+    return ami_contents
 
 
 class FileLookup():

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -24,6 +24,7 @@ import requests
 
 from ..consts import AMI_JSON_URL, GIT_URL, GITLAB_TOKEN
 from ..exceptions import GitLabApiError
+from .warn_user import warn_user
 
 LOG = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
         ami_dict = _get_ami_json(AMI_JSON_URL)
         ami_id = ami_dict[region][name]
     elif GITLAB_TOKEN:
-        # TODO: Remove GitLab repository in favour of JSON URL option.
+        warn_user('Use AMI_JSON_URL feature instead.')
         ami_contents = _get_ami_file(region=region)
         ami_dict = json.loads(ami_contents)
         ami_id = ami_dict[name]

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -109,7 +109,6 @@ class FileLookup():
     """
 
     def __init__(self, git_short='', runway_dir=''):
-        """Init."""
         self.git_short = git_short
         self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
 

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -59,7 +59,7 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
 
 
 def _get_ami_file(region='us-east-1'):
-    """Helper function to get file from Gitlab."""
+    """Get file from Gitlab."""
     LOG.info("Getting AMI from Gitlab")
     server = gitlab.Gitlab(GIT_URL, private_token=GITLAB_TOKEN, api_version=4)
     project = server.projects.get('devops/ansible')
@@ -71,7 +71,7 @@ def _get_ami_file(region='us-east-1'):
 
 
 def _get_ami_json(json_url):
-    """Helper function to get ami from a web url."""
+    """Get ami from a web url."""
     LOG.info("Getting AMI from %s", json_url)
     response = requests.get(json_url)
     assert response.ok, "Error getting ami info from {}".format(json_url)
@@ -94,6 +94,7 @@ class FileLookup():
     """
 
     def __init__(self, git_short='', runway_dir=''):
+        """Init."""
         self.git_short = git_short
         self.runway_dir = os.path.expandvars(os.path.expanduser(runway_dir))
 

--- a/src/foremast/utils/lookups.py
+++ b/src/foremast/utils/lookups.py
@@ -44,13 +44,11 @@ def ami_lookup(region='us-east-1', name='tomcat8'):
     """
     if AMI_JSON_URL:
         ami_dict = _get_ami_json(AMI_JSON_URL)
-        LOG.debug('Lookup AMI table: %s', ami_dict)
         ami_id = ami_dict[region][name]
     elif GITLAB_TOKEN:
         # TODO: Remove GitLab repository in favour of JSON URL option.
         ami_contents = _get_ami_file(region=region)
         ami_dict = json.loads(ami_contents)
-        LOG.debug('Lookup AMI table: %s', ami_dict)
         ami_id = ami_dict[name]
     else:
         ami_id = name
@@ -68,6 +66,7 @@ def _get_ami_file(region='us-east-1'):
     ami_blob = project.files.get(file_path='scripts/{0}.json'.format(region), ref='master')
 
     ami_contents = b64decode(ami_blob.decode()).decode()
+    LOG.debug('AMI File contents: %s', ami_contents)
     return ami_contents
 
 
@@ -77,6 +76,7 @@ def _get_ami_json(json_url):
     response = requests.get(json_url)
     assert response.ok, "Error getting ami info from {}".format(json_url)
     ami_dict = response.json()
+    LOG.debug('AMI json contents: %s', ami_dict)
     return ami_dict
 
 

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -37,8 +37,8 @@ def test_ami_lookup(ami_file):
 
 
 @mock.patch('foremast.utils.lookups.AMI_JSON_URL', new=True)
-@mock.patch('foremast.utils.lookups._get_ami_json')
-def test_json_lookup(ami_file_json):
+@mock.patch('foremast.utils.lookups._get_ami_dict')
+def test_dict_lookup(ami_file_dict):
     """AMI lookup using json url."""
     sample_dict = {
         'us-east-1': {
@@ -48,7 +48,7 @@ def test_json_lookup(ami_file_json):
             'tomcat8': 'ami-yyyy',
         }
     }
-    ami_file_json.return_value = sample_dict
+    ami_file_dict.return_value = sample_dict
     assert ami_lookup(region='us-east-1', name='base_fedora') == 'ami-xxxx'
     assert ami_lookup(region='us-west-2', name='tomcat8') == 'ami-yyyy'
 

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -37,7 +37,7 @@ def test_ami_lookup(ami_file):
 
 @mock.patch('foremast.utils.lookups.AMI_JSON_URL', new=True)
 @mock.patch('foremast.utils.lookups._get_ami_json')
-def test_json_lookup(ami_file):
+def test_json_lookup(ami_file_json):
     """AMI lookup using json url."""
     sample_dict = {
         'us-east-1': {
@@ -47,7 +47,7 @@ def test_json_lookup(ami_file):
             'tomcat8': 'ami-yyyy',
         }
     }
-    ami_file.return_value = sample_dict
+    ami_file_json.return_value = sample_dict
     assert ami_lookup(region='us-east-1', name='base_fedora') == 'ami-xxxx'
     assert ami_lookup(region='us-west-2', name='tomcat8') == 'ami-yyyy'
 

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -21,15 +21,15 @@ from unittest import mock
 from foremast.utils import ami_lookup
 
 
-@mock.patch('foremast.utils.lookups.GITLAB_TOKEN')
-@mock.patch('foremast.utils.lookups.gitlab.Gitlab')
-def test_ami_lookup(gitlab, token):
+@mock.patch('foremast.utils.lookups.GITLAB_TOKEN', return_value=True)
+@mock.patch('foremast.utils.lookups._get_ami_file')
+def test_ami_lookup(ami_file, token):
     """AMI lookup should contact GitLab for JSON table and resolve."""
     sample_dict = {
         'base_fedora': 'ami-xxxx',
-        'tomcat8': 'ami-xxxx',
+        'tomcat8': 'ami-yyyy',
     }
     sample_json = json.dumps(sample_dict)
-    gitlab.return_value.getfile.return_value = {'content': base64.b64encode(sample_json.encode())}
-    assert ami_lookup(name='base_fedora').startswith('ami-xxxx')
-    assert ami_lookup(region='us-west-2').startswith('ami-xxxx')
+    ami_file.return_value = sample_json
+    assert ami_lookup(name='base_fedora') == 'ami-xxxx'
+    assert ami_lookup(region='us-west-2') == 'ami-yyyy'

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -33,3 +33,20 @@ def test_ami_lookup(ami_file, token):
     ami_file.return_value = sample_json
     assert ami_lookup(name='base_fedora') == 'ami-xxxx'
     assert ami_lookup(region='us-west-2') == 'ami-yyyy'
+
+
+@mock.patch('foremast.utils.lookups.AMI_JSON_URL', return_value=True)
+@mock.patch('foremast.utils.lookups._get_ami_json')
+def test_json_lookup(ami_file, json_url):
+    """AMI lookup should contact GitLab for JSON table and resolve."""
+    sample_dict = {
+        'us-east-1': {
+            'base_fedora': 'ami-xxxx',
+        },
+        'us-west-2': {
+            'tomcat8': 'ami-yyyy',
+        }
+    }
+    ami_file.return_value = sample_dict
+    assert ami_lookup(region='us-east-1', name='base_fedora') == 'ami-xxxx'
+    assert ami_lookup(region='us-west-2', name='tomcat8') == 'ami-yyyy'

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -52,5 +52,5 @@ def test_json_lookup(ami_file_json):
 
 
 def test_no_external_lookup():
-    """AMI lookup should contact GitLab for JSON table and resolve."""
+    """AMI lookup not using json or gitlab."""
     assert ami_lookup(region='us-east-1', name='no_external') == 'no_external'

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -14,7 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Ensure AMI names can be translated."""
-import base64
 import json
 from unittest import mock
 

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -38,7 +38,7 @@ def test_ami_lookup(ami_file, token):
 @mock.patch('foremast.utils.lookups.AMI_JSON_URL', return_value=True)
 @mock.patch('foremast.utils.lookups._get_ami_json')
 def test_json_lookup(ami_file, json_url):
-    """AMI lookup should contact GitLab for JSON table and resolve."""
+    """AMI lookup using json url."""
     sample_dict = {
         'us-east-1': {
             'base_fedora': 'ami-xxxx',
@@ -50,3 +50,8 @@ def test_json_lookup(ami_file, json_url):
     ami_file.return_value = sample_dict
     assert ami_lookup(region='us-east-1', name='base_fedora') == 'ami-xxxx'
     assert ami_lookup(region='us-west-2', name='tomcat8') == 'ami-yyyy'
+
+
+def test_no_external_lookup():
+    """AMI lookup should contact GitLab for JSON table and resolve."""
+    assert ami_lookup(region='us-east-1', name='no_external') == 'no_external'

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -17,6 +17,7 @@
 import json
 from unittest import mock
 
+import pytest
 from foremast.utils import ami_lookup
 
 
@@ -30,8 +31,9 @@ def test_ami_lookup(ami_file):
     }
     sample_json = json.dumps(sample_dict)
     ami_file.return_value = sample_json
-    assert ami_lookup(name='base_fedora') == 'ami-xxxx'
-    assert ami_lookup(region='us-west-2') == 'ami-yyyy'
+    with pytest.warns(UserWarning):
+        assert ami_lookup(name='base_fedora') == 'ami-xxxx'
+        assert ami_lookup(region='us-west-2') == 'ami-yyyy'
 
 
 @mock.patch('foremast.utils.lookups.AMI_JSON_URL', new=True)

--- a/tests/test_ami_lookup.py
+++ b/tests/test_ami_lookup.py
@@ -21,9 +21,9 @@ from unittest import mock
 from foremast.utils import ami_lookup
 
 
-@mock.patch('foremast.utils.lookups.GITLAB_TOKEN', return_value=True)
+@mock.patch('foremast.utils.lookups.GITLAB_TOKEN', new=True)
 @mock.patch('foremast.utils.lookups._get_ami_file')
-def test_ami_lookup(ami_file, token):
+def test_ami_lookup(ami_file):
     """AMI lookup should contact GitLab for JSON table and resolve."""
     sample_dict = {
         'base_fedora': 'ami-xxxx',
@@ -35,9 +35,9 @@ def test_ami_lookup(ami_file, token):
     assert ami_lookup(region='us-west-2') == 'ami-yyyy'
 
 
-@mock.patch('foremast.utils.lookups.AMI_JSON_URL', return_value=True)
+@mock.patch('foremast.utils.lookups.AMI_JSON_URL', new=True)
 @mock.patch('foremast.utils.lookups._get_ami_json')
-def test_json_lookup(ami_file, json_url):
+def test_json_lookup(ami_file):
     """AMI lookup using json url."""
     sample_dict = {
         'us-east-1': {

--- a/tests/utils/test_file_lookups.py
+++ b/tests/utils/test_file_lookups.py
@@ -38,7 +38,7 @@ def test_init(gitlab):
 
 
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_project_id_exception(mock_gitlab):
+def test_project_exception(mock_gitlab):
     """Check resolving GitLab Project ID fails with exception."""
     mock_gitlab.Gitlab.return_value.projects.get.return_value = False
 
@@ -47,12 +47,11 @@ def test_project_id_exception(mock_gitlab):
 
 
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_project_id_success(mock_gitlab):
+def test_project_success(mock_gitlab):
     """Check resolving GitLab Project ID is successful."""
-    project_id = object
     mock_gitlab.Gitlab.return_value.projects.get.return_value = object
     seeker = FileLookup()
-    assert seeker.project == project_id
+    assert seeker.project is object
 
 
 @mock.patch('foremast.utils.lookups.gitlab')
@@ -93,7 +92,6 @@ def test_filelookup_attr():
 
     assert my_git.git_short == ''
     assert my_git.server is None
-    assert my_git.project_id == ''
 
 
 @mock.patch('foremast.utils.lookups.gitlab')

--- a/tests/utils/test_file_lookups.py
+++ b/tests/utils/test_file_lookups.py
@@ -54,36 +54,36 @@ def test_project_success(mock_gitlab):
     assert seeker.project is object
 
 
+@mock.patch.object(FileLookup, 'remote_file', return_value=TEST_JSON)
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_get(gitlab):
+def test_get(gitlab, mock_lookup):
     """Check _get_ method."""
     my_git = FileLookup()
 
-    with mock.patch.object(FileLookup, 'remote_file', return_value=TEST_JSON) as mock_method:
-        result = my_git.get()
-        assert isinstance(result, str)
-        assert TEST_JSON == my_git.get()
+    result = my_git.get()
+    assert isinstance(result, str)
+    assert TEST_JSON == my_git.get()
 
 
+@mock.patch.object(FileLookup, 'get', return_value=TEST_JSON)
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_json(gitlab):
+def test_json(gitlab, mock_lookup):
     """Check _json_ method."""
     my_git = FileLookup()
 
-    with mock.patch.object(FileLookup, 'get', return_value=TEST_JSON) as mock_method:
-        result = my_git.json()
-        assert isinstance(result, dict)
-        assert result['ship'] == 'pirate'
+    result = my_git.json()
+    assert isinstance(result, dict)
+    assert result['ship'] == 'pirate'
 
 
+@mock.patch.object(FileLookup, 'get', return_value=TEST_JSON + '}')
 @mock.patch('foremast.utils.lookups.gitlab')
-def test_invalid_json(gitlab):
+def test_invalid_json(gitlab, mock_lookup):
     """Check invalid JSON."""
     my_git = FileLookup()
 
-    with mock.patch.object(FileLookup, 'get', return_value=TEST_JSON + '}') as mock_method:
-        with pytest.raises(SystemExit):
-            my_git.json()
+    with pytest.raises(SystemExit):
+        my_git.json()
 
 
 def test_filelookup_attr():

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ skip_missing_interpreters = True
 [pytest]
 pep8maxlinelength = 120
 
+[pydocstyle]
+add-ignore = D107
+
 [testenv]
 deps = -rrequirements-dev.txt
 commands = py.test -s -v --cov-report term-missing --cov-report html --cov foremast tests/


### PR DESCRIPTION
We should use version 4 of gitlab api. The api v3 will be removed in a future version later this year.