### PR TITLE
Fix failover dns

### DIFF
--- a/src/foremast/dns/create_dns.py
+++ b/src/foremast/dns/create_dns.py
@@ -33,6 +33,7 @@ class SpinnakerDns:
 
     Returns:
         str: FQDN of application
+
     """
 
     def __init__(self, app=None, env=None, region=None, elb_subnet=None, prop_path=None):
@@ -55,9 +56,10 @@ class SpinnakerDns:
         """Create dns entries in route53.
 
         Args:
-            hasregion (bool): The DNS entry should have region on it
+            regionspecific (bool): The DNS entry should have region on it
         Returns:
-            Auto-generated DNS name for the Elastic Load Balancer.
+            str: Auto-generated DNS name for the Elastic Load Balancer.
+
         """
         if regionspecific:
             dns_elb = self.generated.dns()['elb_region']
@@ -83,7 +85,7 @@ class SpinnakerDns:
         return dns_elb
 
     def create_failover_dns(self, primary_region='us-east-1'):
-        """Create dns entries in route53 for multiregion failover setups
+        """Create dns entries in route53 for multiregion failover setups.
 
         Args:
             primary_region (str): primary AWS region for failover

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -191,18 +191,21 @@ class ForemastRunner(object):
         elb_subnet = self.configs[self.env]['elb']['subnet_purpose']
         regions = self.configs[self.env]['regions']
         failover = self.configs[self.env]['dns']['failover_dns']
+        primary_region = self.configs['pipeline']['primary_region']
         regionspecific_dns = self.configs[self.env]['dns']['region_specific']
 
         dnsobj = dns.SpinnakerDns(
             app=self.app, env=self.env, region=self.region, prop_path=self.json_path, elb_subnet=elb_subnet)
+
         if len(regions) > 1 and failover:
             dnsobj.create_elb_dns(regionspecific=True)
-            primary_region = self.configs['pipeline']['primary_region']
             dnsobj.create_failover_dns(primary_region=primary_region)
         else:
-            dnsobj.create_elb_dns(regionspecific=False)
-            if regionspecific_dns:  # If true, Also create a region specific DNS record
+            if regionspecific_dns:
                 dnsobj.create_elb_dns(regionspecific=True)
+
+            if self.region == primary_region:
+                dnsobj.create_elb_dns(regionspecific=False)
 
     def create_autoscaling_policy(self):
         """Create Scaling Policy for app in environment"""


### PR DESCRIPTION
We should only update the global dns record when it matches the primary region.

This addresses a problem where the secondary, region specific, domain was updating the global dns record.