### PR TITLE
Remove reference to invalid stage

### DIFF
--- a/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
+++ b/src/foremast/templates/pipeline/pipeline_wrapper.json.j2
@@ -29,8 +29,7 @@
   ],
   "stages": [
     {% if data.app.deploy_type not in ["lambda", "s3", "datapipeline"] %}
-      {% include "pipeline/stage-bake.json.j2" %},
-      {% include "pipeline/stage-tagger.json.j2" %}
+      {% include "pipeline/stage-bake.json.j2" %}
     {% endif %}
    ]
 }


### PR DESCRIPTION
I included a custom reference to a stage in 2556e13d387b00bc45654db25167f488cf80919e.

The `stage-tagger.json.j2` does not exist and this removes that reference.