### PR TITLE
overrides regions in templates with regions in configs

### DIFF
--- a/src/foremast/configs/outputs.py
+++ b/src/foremast/configs/outputs.py
@@ -88,7 +88,9 @@ def write_variables(app_configs=None, out_file='', git_short=''):
             rendered_configs = json.loads(
                 get_template('configs/configs.json.j2', env=env, app=generated.app_name(), profile=instance_profile))
             json_configs[env] = dict(DeepChainMap(configs, rendered_configs))
-            for region in json_configs[env]['regions']:
+            region_list = configs['regions']
+            json_configs[env]['regions'] = region_list  # removes regions defined in templates but not configs.
+            for region in region_list:
                 region_config = json_configs[env][region]
                 json_configs[env][region] = dict(DeepChainMap(region_config, rendered_configs))
         else:

--- a/src/foremast/configs/outputs.py
+++ b/src/foremast/configs/outputs.py
@@ -88,7 +88,7 @@ def write_variables(app_configs=None, out_file='', git_short=''):
             rendered_configs = json.loads(
                 get_template('configs/configs.json.j2', env=env, app=generated.app_name(), profile=instance_profile))
             json_configs[env] = dict(DeepChainMap(configs, rendered_configs))
-            region_list = configs['regions']
+            region_list = configs.get('regions', rendered_configs['regions'])
             json_configs[env]['regions'] = region_list  # removes regions defined in templates but not configs.
             for region in region_list:
                 region_config = json_configs[env][region]


### PR DESCRIPTION
Since we moved to dicts for the `regions` block, the default in our templates gets put in even if excluded in application configs. This makes sure to only use the regions in the application config. If not provided in the application config, it will use the default in the templates. 