### PR TITLE
fixed s3 app dns ttl issue with region specific configs

### DIFF
--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -111,7 +111,7 @@ class S3Apps(object):
         dns_kwargs = {
             'dns_name': self.bucket,
             'dns_name_aws': s3_endpoint,
-            'dns_ttl': self.properties[self.env]['dns']['ttl']
+            'dns_ttl': self.properties['dns']['ttl']
         }
 
         for zone_id in zone_ids:


### PR DESCRIPTION
This was something that got missed while adding region specific configs.  