### PR TITLE
Better merge of default and application security group rules.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 awscli
 boto3
+deepmerge
 gogo-utils
 jinja2
 murl

--- a/src/foremast/securitygroup/create_securitygroup.py
+++ b/src/foremast/securitygroup/create_securitygroup.py
@@ -50,7 +50,7 @@ from deepmerge import conservative_merger
 from ..consts import DEFAULT_SECURITYGROUP_RULES
 from ..exceptions import (ForemastConfigurationFileError, SpinnakerSecurityGroupCreationFailed,
                           SpinnakerSecurityGroupError)
-from ..utils import (get_details, get_properties, get_security_group_id, get_template, get_vpc_id, wait_for_task)
+from ..utils import get_details, get_properties, get_security_group_id, get_template, get_vpc_id, wait_for_task
 
 
 class SpinnakerSecurityGroup(object):


### PR DESCRIPTION
We have the ability add default security group rules via our `config.py` files.

There are scenarios where an application (via `application.json`) needs to add a rule, which correspond to one already defined in `config.py`. In those scenarios, the default definition from `config.py` will win and those definitions will be used instead of what an application has defined.

In does the following:
```
DEFAULT = {'test_app': [{'start_port': 31,'end_port': 31,}]}
APP = {'test_app': [{'start_port': 30,'end_port': 30,}]}

OLD_BEHAVIOR =  {
        'test_app': [
            {
                'start_port': 31,
                'end_port': 31,
            }
        ]
}

NEW_BEHAVIOR =  {
        'test_app': [
            {
                'start_port': 30,
                'end_port': 30,
            },
            {
                'start_port': 31,
                'end_port': 31,
            }
        ]
}

```