### PR TITLE
Flat s3 deployments

### DIFF
--- a/_docs/configuration_files/application_json.rst
+++ b/_docs/configuration_files/application_json.rst
@@ -511,6 +511,8 @@ Spinnaker strategy to use for deployments.
          deploy to CANARY path
        - ``"alpha"`` - Only used in S3 deployments. Causes pipeline to first
          deploy to an ALPHA path
+       - ``"mirror"`` - Only used in S3 deployments. Contents are deployed as-is.
+       No version or LATEST directory. 
 
 ``security_group`` Block
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -94,10 +94,10 @@ class S3Deployment(object):
     def upload_artifacts(self):
         """Upload artifacts to S3 and copy to correct path depending on strategy."""
         deploy_strategy = self.properties["deploy_strategy"]
+
+        mirror = False
         if deploy_strategy == "mirror":
             mirror = True
-        else:
-            mirror = False
 
         self._upload_artifacts_to_path(mirror=mirror)
         if deploy_strategy == "highlander":
@@ -138,7 +138,8 @@ class S3Deployment(object):
         else:
             dest_uri = self.s3_version_uri
 
-        cmd = 'aws s3 sync {} {} --delete --exact-timestamps --profile {}'.format(self.artifact_path, dest_uri, self.env)
+        cmd = 'aws s3 sync {} {} --delete --exact-timestamps --profile {}'.format(self.artifact_path,
+                                                                                  dest_uri, self.env)
         return cmd
 
     def _upload_artifacts_to_path(self, mirror=False):

--- a/src/foremast/s3/s3deploy.py
+++ b/src/foremast/s3/s3deploy.py
@@ -131,15 +131,15 @@ class S3Deployment(object):
         """
         if flat:
             cmd = 'aws s3 sync {} {} --delete --exact-timestamps --profile {}'.format(self.artifact_path,
-                                                                                    self.s3_flat_uri, self.env)
+                                                                                      self.s3_flat_uri, self.env)
         else:
             cmd = 'aws s3 sync {} {} --delete --exact-timestamps --profile {}'.format(self.artifact_path,
-                                                                                    self.s3_version_uri, self.env)
+                                                                                      self.s3_version_uri, self.env)
         return cmd
 
     def _upload_artifacts_to_path(self, flat=False):
         """Recursively upload directory contents to S3.
-        
+
         Args:
             flat (bool): If true, uses a flat directory structure instead of nesting under a version.
         """

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -1,0 +1,42 @@
+"""Test S3 Deploy"""
+
+import pytest
+from unittest import mock
+
+from foremast import s3
+
+@pytest.fixture
+@mock.patch('foremast.s3.s3deploy.get_properties')
+@mock.patch('foremast.s3.s3deploy.get_details')
+def s3deployment(mock_get_details, mock_get_props):
+    """Creates S3Deployment Fixture"""
+    mock_get_props.return_value = {"deploy_strategy": "highlander",
+                                   "s3": {"path": "/"}}
+    mock_get_details.return_value.s3_app_bucket.return_value = "testapp"
+    deployobj = s3.S3Deployment(app="testapp",
+                                env="dev",
+                                region="us-east-1",
+                                prop_path="/",
+                                artifact_path="/artifact",
+                                artifact_version="1")
+    return deployobj
+
+
+def test_get_cmd(s3deployment):
+    """Tests s3.S3Deployment._get_upload_cmd returns correct cmd"""
+    expected_nomirror_cmd = "aws s3 sync /artifact s3://testapp/1 --delete --exact-timestamps --profile dev"
+    expected_mirror_cmd = "aws s3 sync /artifact s3://testapp/ --delete --exact-timestamps --profile dev"
+    actual_nomirror_cmd = s3deployment._get_upload_cmd()
+    actual_mirror_cmd = s3deployment._get_upload_cmd(mirror=True)
+    assert actual_nomirror_cmd == expected_nomirror_cmd
+    assert actual_mirror_cmd == expected_mirror_cmd
+    
+def test_path_formatter(s3deployment):
+    """Tests s3.S3Deployment._path_formatter returns correct path"""
+    expected_latest_path = "s3://testapp/LATEST"
+    expected_mirror_path = "s3://testapp/"
+    actual_latest_path = s3deployment._path_formatter("LATEST")
+    actual_mirror_path = s3deployment._path_formatter("MIRROR")
+    assert actual_latest_path == expected_latest_path
+    assert actual_mirror_path == expected_mirror_path
+


### PR DESCRIPTION
This enabled the ability to do "flat" s3 deployments, flat meaning no version and no LATEST directory. The contents are uploaded in the exact structure as the artifact. 

This does DELETE everything else in the bucket. It is expected, but potentially dangerous bahavior. Is it worth coming up with some protection? 

This works by simply setting "deploy_strategy" to "flat"  in application-master-env.json. 