### PR TITLE
Updated Athena and Glue permissions

### DIFF
--- a/src/foremast/templates/infrastructure/iam/athena.json.j2
+++ b/src/foremast/templates/infrastructure/iam/athena.json.j2
@@ -5,7 +5,8 @@
                 "athena:StopQueryExecution", 
                 "athena:GetQueryExecution", 
                 "athena:GetQueryResults", 
-                "athena:RunQuery" 
+                "athena:RunQuery",
+                "glue:Get*"
             ],
             "Effect": "Allow",
             "Resource": "*"

--- a/src/foremast/templates/infrastructure/iam/glue.json.j2
+++ b/src/foremast/templates/infrastructure/iam/glue.json.j2
@@ -1,8 +1,7 @@
         {
             "Sid": "GlueLimitedAccess",
             "Action": [
-                "glue:GetTable*",
-                "glue:GetDatabase*"
+                "glue:Get*"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
- Athena now includes glue:Get* as this is now required once Athena's data catalog is upgraded.
- Glue was converted to generic Get* as this might need to be tweaked in
the future