### PR TITLE
Updates bucket naming to include region if not primary region

### DIFF
--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -145,25 +145,29 @@ class ForemastRunner(object):
     def deploy_s3app(self):
         """Deploys artifacts contents to S3 bucket"""
         utils.banner("Deploying S3 App")
+        primary_region = self.configs['pipeline']['primary_region']
         s3obj = s3.S3Deployment(
             app=self.app,
             env=self.env,
             region=self.region,
             prop_path=self.json_path,
             artifact_path=self.artifact_path,
-            artifact_version=self.artifact_version)
+            artifact_version=self.artifact_version,
+            primary_region=primary_region)
         s3obj.upload_artifacts()
 
     def promote_s3app(self):
         """promotes S3 deployment to LATEST"""
         utils.banner("Promoting S3 App")
+        primary_region = self.configs['pipeline']['primary_region']
         s3obj = s3.S3Deployment(
             app=self.app,
             env=self.env,
             region=self.region,
             prop_path=self.json_path,
             artifact_path=self.artifact_path,
-            artifact_version=self.artifact_version)
+            artifact_version=self.artifact_version,
+            primary_region=primary_region)
         s3obj.promote_artifacts(promote_stage=self.promote_stage)
 
     def create_secgroups(self):

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -134,7 +134,8 @@ class ForemastRunner(object):
     def create_s3app(self):
         """Create S3 infra for s3 applications"""
         utils.banner("Creating S3 App Infrastructure")
-        s3obj = s3.S3Apps(app=self.app, env=self.env, region=self.region, prop_path=self.json_path)
+        primary_region = self.configs['pipeline']['primary_region']
+        s3obj = s3.S3Apps(app=self.app, env=self.env, region=self.region, prop_path=self.json_path, primary_region=primary_region)
         s3obj.create_bucket()
 
     def deploy_s3app(self):

--- a/src/foremast/runner.py
+++ b/src/foremast/runner.py
@@ -135,7 +135,11 @@ class ForemastRunner(object):
         """Create S3 infra for s3 applications"""
         utils.banner("Creating S3 App Infrastructure")
         primary_region = self.configs['pipeline']['primary_region']
-        s3obj = s3.S3Apps(app=self.app, env=self.env, region=self.region, prop_path=self.json_path, primary_region=primary_region)
+        s3obj = s3.S3Apps(app=self.app,
+                          env=self.env,
+                          region=self.region,
+                          prop_path=self.json_path,
+                          primary_region=primary_region)
         s3obj.create_bucket()
 
     def deploy_s3app(self):

--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -38,7 +38,7 @@ class S3Apps(object):
             env (str): Environment/Account
             region (str): AWS Region
             prop_path (str): Path of environment property file
-            primary_region (str): The primary region for the application. 
+            primary_region (str): The primary region for the application.
         """
         self.app_name = app
         self.env = env
@@ -75,7 +75,7 @@ class S3Apps(object):
                 _response = self.s3client.create_bucket(ACL=self.s3props['bucket_acl'], Bucket=self.bucket)
             else:
                 _response = self.s3client.create_bucket(ACL=self.s3props['bucket_acl'], Bucket=self.bucket,
-                                                    CreateBucketConfiguration={'LocationConstraint': self.region})
+                                                        CreateBucketConfiguration={'LocationConstraint': self.region})
             LOG.debug('Response creating bucket: %s', _response)
             LOG.info('%s - S3 Bucket Upserted', self.bucket)
             if self.s3props['bucket_policy']:

--- a/tests/s3/test_s3deploy.py
+++ b/tests/s3/test_s3deploy.py
@@ -21,7 +21,6 @@ def s3deployment(mock_get_details, mock_get_props):
                                 artifact_version="1")
     return deployobj
 
-
 def test_get_cmd(s3deployment):
     """Tests s3.S3Deployment._get_upload_cmd returns correct cmd"""
     expected_nomirror_cmd = "aws s3 sync /artifact s3://testapp/1 --delete --exact-timestamps --profile dev"


### PR DESCRIPTION
This PR will use different naming convention for region specific buckets outside the primary region. The reason the primary region does not have a different name is for backwards compatibility. 