### PR TITLE
fixed issue with non-east buckets already existing and giving errors

### DIFF
--- a/src/foremast/s3/s3apps.py
+++ b/src/foremast/s3/s3apps.py
@@ -77,7 +77,8 @@ class S3Apps(object):
             else:
                 if not bucket_exists:
                     _response = self.s3client.create_bucket(ACL=self.s3props['bucket_acl'], Bucket=self.bucket,
-                                                            CreateBucketConfiguration={'LocationConstraint': self.region})
+                                                            CreateBucketConfiguration={
+                                                                'LocationConstraint': self.region})
                 else:
                     _response = "bucket already exists, skipping create for non-standard region buckets."
             LOG.debug('Response creating bucket: %s', _response)


### PR DESCRIPTION
checks that non-east buckets exist before trying to create. 

https://stackoverflow.com/questions/10346378/boto-s3-error-bucketalreadyownedbyyou description of why this logic is necessary. 