### PR TITLE
pin botocore to fix pypi caching issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 awscli
+botocore==1.10.8
 boto3
 deepmerge
 gogo-utils


### PR DESCRIPTION
We keep getting bit by botocore updating and the pypi caches not updating. Lets pin the version for now and re-evaluate in the future